### PR TITLE
OCaml completions

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,5 +1,16 @@
 (executable
  (public_name menhir-lsp)
  (name main)
- (preprocess (pps lwt_ppx))
- (libraries menhirSyntax ocamllexSyntax linol linol-lwt containers ordering re))
+ (preprocess
+  (pps lwt_ppx))
+ (libraries
+  merlin-lib.kernel
+  merlin-lib.query_commands
+  menhirSyntax
+  ocamllexSyntax
+  linol
+  linol-lwt
+  containers
+  ordering
+  re
+  stdune))

--- a/bin/keywords.ml
+++ b/bin/keywords.ml
@@ -92,8 +92,7 @@ If a quoted identifier `qid_i` is present, then it is considered an alias for th
       None,
       [
         md_fenced "%public option(X):\n    | { None }\n    | x = X { Some x }";
-        "exposes the nonterminal symbol `option` for use within client grammar \
-         modules";
+        "exposes the nonterminal symbol `option` to client grammar modules.";
         manual_ref "%3Asplit";
       ] );
     ( "%inline",

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -22,12 +22,12 @@ class lsp_server =
         let* d = self#find_doc uri in
         let text = d.content in
         let td =
-          Lsp.Text_document.make ~position_encoding:positionEncoding
+          Text_document.make ~position_encoding:positionEncoding
             (DidOpenTextDocumentParams.create
                ~textDocument:
                  { text; version = d.version; languageId = d.languageId; uri })
         in
-        let ofs = Lsp.Text_document.absolute_position td pos in
+        let ofs = Text_document.absolute_position td pos in
         let max_reach = min ofs 500 in
         (* limit the search to the previous 500 chars *)
         let prefix = CCString.sub text (ofs - max_reach) max_reach in
@@ -50,7 +50,7 @@ class lsp_server =
         notify_back#send_log_msg ~type_:MessageType.Info
           (spr "Word under cursor: |%s| %s" word (Range.show range))
         |> ignore;
-        Some { v = word; p = range }
+        Some { v = word; p = range; td }
 
     method private _dispatch : type r.
         uri ->
@@ -86,15 +86,21 @@ class lsp_server =
         Lwt.return
         @@
         let open O in
-        let word = self#_word_at_position ~notify_back ~uri ~pos in
-        let+ comps =
-          self#_dispatch ~notify_back uri ~mll_handler:(Mll.completions ~pos)
-            ~mly_handler:(Mly.completions ~word ~pos)
+        let opt_word = self#_word_at_position ~notify_back ~uri ~pos in
+        let merlin_compls =
+          (let* word = opt_word in
+           get_merlin_compls ~notify_back ~uri ~pos word)
+          |> get_or ~default:[]
         in
-        notify_back#send_log_msg ~type_:MessageType.Info
-          (spr "# completions: %d" (List.length comps))
-        |> ignore;
-        `List comps
+        log_info ~notify_back
+        @@ spr "# merlin completions: %d" (L.length merlin_compls);
+        let+ grammar_compls =
+          self#_dispatch ~notify_back uri ~mll_handler:(Mll.completions ~pos)
+            ~mly_handler:(Mly.completions ~word:opt_word ~pos)
+        in
+        log_info ~notify_back
+          (spr "# completions: %d" (List.length grammar_compls));
+        `List (grammar_compls @ merlin_compls)
 
     method! config_symbol = Some (`Bool true)
 
@@ -212,17 +218,18 @@ class lsp_server =
       notify_back#send_log_msg ~type_:Info
         (spr "Processing document %s" filename);%lwt
       let go buffers loader diagnose =
-        let%lwt new_state, new_diags =
+        let new_state, new_diags =
           match loader filename contents with
           | Ok new_state ->
               Hashtbl.replace buffers uri new_state;
-              Lwt.return (Some new_state, [])
-          | Error diags -> Lwt.return (Hashtbl.find_opt buffers uri, diags)
+              (Some new_state, [])
+          | Error diags -> (Hashtbl.find_opt buffers uri, diags)
         in
         (* diagnoses for the new state (empty) *)
         let diags = O.map_or ~default:[] diagnose new_state in
         notify_back#send_diagnostic (diags @ new_diags)
       in
+      (* consider matching on TextDocumentItem.languageId *)
       match Filename.extension filename with
       | ".mll" -> go mll_buffers Mll.load_state_from_contents Mll.diagnostics
       | ".mly" ->
@@ -233,8 +240,10 @@ class lsp_server =
           @@ spr "Unhandled document type: %s" ext
 
     (* We now override the [on_notify_doc_did_open] method that will be called
-          by the server each time a new document is opened. *)
+            by the server each time a new document is opened. *)
     method on_notif_doc_did_open ~notify_back d ~content : unit Linol_lwt.t =
+      find_merlin_config ~notify_back ~uri:d.uri |> ignore;
+      notify_back#send_log_msg ~type_:Info (spr "Language id: %s" d.languageId);%lwt
       self#_on_doc ~notify_back d.uri content
 
     (* Similarly, we also override the [on_notify_doc_did_change] method that will be called

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -37,7 +37,10 @@ class lsp_server =
         let* start_ofs =
           try
             Re.Str.(
-              search_backward (regexp {|[^a-zA-Z0-9_$%]|}) prefix (max_reach - 1))
+              search_backward
+                (regexp {|[^a-zA-Z0-9_$%.]|})
+                (* should include all trigger characters *)
+                prefix (max_reach - 1))
             |> some
           with _ -> None
         in
@@ -76,7 +79,7 @@ class lsp_server =
           allCommitCharacters = None;
           completionItem = None;
           resolveProvider = None;
-          triggerCharacters = Some [ "%"; "$" ];
+          triggerCharacters = Some [ "%"; "$"; "." ];
           workDoneProgress = None;
         }
 
@@ -94,13 +97,14 @@ class lsp_server =
         in
         log_info ~notify_back
         @@ spr "# merlin completions: %d" (L.length merlin_compls);
-        let+ grammar_compls =
+        let grammar_compls =
           self#_dispatch ~notify_back uri ~mll_handler:(Mll.completions ~pos)
             ~mly_handler:(Mly.completions ~word:opt_word ~pos)
+          |> get_or ~default:[]
         in
         log_info ~notify_back
-          (spr "# completions: %d" (List.length grammar_compls));
-        `List (grammar_compls @ merlin_compls)
+          (spr "# completions: %d" (L.length grammar_compls));
+        some @@ `List (grammar_compls @ merlin_compls)
 
     method! config_symbol = Some (`Bool true)
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -87,10 +87,11 @@ class lsp_server =
       fun ~notify_back ~id:_ ~uri ~pos ~ctx:_ ~workDoneToken:_
           ~partialResultToken:_ _doc_state ->
         let open O in
-        let opt_word = self#_word_at_position ~notify_back ~uri ~pos in
+        let word = self#_word_at_position ~notify_back ~uri ~pos in
         let grammar_compls =
-          self#_dispatch ~notify_back uri ~mll_handler:(Mll.completions ~pos)
-            ~mly_handler:(Mly.completions ~word:opt_word ~notify_back ~pos ~uri)
+          self#_dispatch ~notify_back uri
+            ~mll_handler:(Mll.completions ~notify_back ~pos ~uri ~word)
+            ~mly_handler:(Mly.completions ~notify_back ~pos ~uri ~word)
           |> get_or ~default:[]
         in
         log_info ~notify_back

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -86,25 +86,16 @@ class lsp_server =
     method! on_req_completion =
       fun ~notify_back ~id:_ ~uri ~pos ~ctx:_ ~workDoneToken:_
           ~partialResultToken:_ _doc_state ->
-        Lwt.return
-        @@
         let open O in
         let opt_word = self#_word_at_position ~notify_back ~uri ~pos in
-        let merlin_compls =
-          (let* word = opt_word in
-           get_merlin_compls ~notify_back ~uri ~pos word)
-          |> get_or ~default:[]
-        in
-        log_info ~notify_back
-        @@ spr "# merlin completions: %d" (L.length merlin_compls);
         let grammar_compls =
           self#_dispatch ~notify_back uri ~mll_handler:(Mll.completions ~pos)
-            ~mly_handler:(Mly.completions ~word:opt_word ~pos)
+            ~mly_handler:(Mly.completions ~word:opt_word ~notify_back ~pos ~uri)
           |> get_or ~default:[]
         in
         log_info ~notify_back
           (spr "# completions: %d" (L.length grammar_compls));
-        some @@ `List (grammar_compls @ merlin_compls)
+        `List grammar_compls |> some |> Lwt.return
 
     method! config_symbol = Some (`Bool true)
 

--- a/bin/menhir.ml
+++ b/bin/menhir.ml
@@ -17,6 +17,31 @@ type state = {
   symbols : string located list;
 }
 
+let get_conflicts_file ~uri =
+  let module P = Stdune.Path in
+  let module F = Filename in
+  let grammar_path = DocumentUri.to_path uri in
+  let grammar_name = F.basename grammar_path in
+  let grammar_slug = F.remove_extension grammar_name in
+  let open R in
+  let* root_dir, context = get_build_dirs () in
+  let p_root = P.of_string root_dir in
+  let p_context = P.of_string (F.concat root_dir context) in
+  let p_grammar = P.of_string (F.dirname grammar_path) in
+  match P.drop_prefix p_grammar ~prefix:p_root with
+  | None ->
+      Error
+        (spr
+           "No config found for %s. Make sure (menhir (modules .. %s ..)) is \
+            included in the stanza's dune file."
+           grammar_name grammar_slug)
+  | Some rel ->
+      let p_conflicts = P.append_local p_context rel in
+      let conflicts_file =
+        F.concat (P.to_string p_conflicts) (grammar_slug ^ ".conflicts")
+      in
+      Ok conflicts_file
+
 let rec string_of_params : parameter -> string = function
   | M.Syntax.ParamVar p -> p.v
   | M.Syntax.ParamApp (p, ps) ->
@@ -278,48 +303,14 @@ let hover (state : state) ~(pos : Position.t) : Hover.t option =
 let diagnostics ~(notify_back : notify_back) ~(uri : uri) (_s : state) :
     Lsp.Types.Diagnostic.t list =
   let log = log_info ~notify_back in
-  (* move this code to load function *)
-  let grammar_file = DocumentUri.to_path uri in
-  let s =
-    let inp = Unix.open_process_in "dune describe workspace" in
-    let s = CCSexp.parse_chan inp in
-    In_channel.close inp;
-    s
-  in
-  let root_dir, context =
-    match s with
-    | Ok
-        (`List
-           (`List [ `Atom "root"; `Atom root_dir ]
-           :: `List [ `Atom "build_context"; `Atom context ]
-           :: _)) ->
-        (root_dir, context)
-    | _ -> ("", "")
-  in
-  log (spr "Sys.executable_name: %s" @@ Sys.executable_name);
-  log (spr "Sys.getcwd: %s" @@ Sys.getcwd ());
-  let module P = Stdune.Path in
-  let slug = Filename.(remove_extension grammar_file |> basename) in
-  let p_root = P.of_string root_dir in
-  let p_context = P.of_string (Filename.concat root_dir context) in
-  let p_grammar = P.of_string (Filename.dirname grammar_file) in
-  let p_conflicts =
-    let rel = P.drop_prefix p_grammar ~prefix:p_root in
-    match rel with
-    | None -> p_context
-    (* No config found for <grammar_name>. Make sure (menhir (modules .. <grammar_name> ..)) is present in the stanza's dune file. *)
-    | Some rel -> P.append_local p_context rel
-  in
-  (* if the output of dune describe is not available (e.g. due to error 'A running dune (pid: ..) instance has locked the build directory.'), use the workspace root reported by the client and assume that's the root folder of the dune project. *)
-  let conflicts_file =
-    Filename.concat (P.to_string p_conflicts) (slug ^ ".conflicts")
-  in
-  log (spr "p_conflicts: %s" conflicts_file);
   try
+    let open R in
+    let conflicts_file = get_conflicts_file ~uri |> get_exn in
+    log @@ spr "conflicts_file: %s" conflicts_file;
     let module P = CCParse in
     let module S = CCString in
     let mk_diag (toks : token located list) lines =
-      let message = S.concat "\n" @@ List.rev lines in
+      let message = S.concat "\n" @@ lines in
       Diagnostic.create ~range:Range.first_line ~source:conflicts_file
         ~relatedInformation:
           L.(
@@ -330,7 +321,7 @@ let diagnostics ~(notify_back : notify_back) ~(uri : uri) (_s : state) :
             DiagnosticRelatedInformation.create
               ~location:
                 (Location.create ~uri ~range:(Range.of_lexical_positions tk.p))
-              ~message:(spr "%s is defined here" tk.v.terminal))
+              ~message:(spr "%s is involved." tk.v.terminal))
         ~message:
           (* Contrary to the OCaml type, the protocol doesn't support Markdown in the diagnostic message. (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic), and in fact the vscode extension crashes. Quite the pickle, because the bits of the conflict message showing derivations trees require a monospace font for best viewing.
 
@@ -339,38 +330,33 @@ let diagnostics ~(notify_back : notify_back) ~(uri : uri) (_s : state) :
           *)
           (`String message) ()
     in
-    let entry_prefix = "** Conflict" in
     let tokens_prefix = "** Tokens involved:" in
     In_channel.with_open_text conflicts_file (fun inp ->
-        In_channel.input_all inp
+        In_channel.input_all inp |> S.trim |> S.split ~by:"\n"
         (* |> S.replace ~sub:"\n\n" ~by:"\n```\n" *)
         (* markdown not supported *)
-        |> S.split ~by:"\n"
-        |> L.drop_while (String.equal "")
-        |> List.fold_left
-             (fun acc line ->
-               let chop s =
-                 s |> S.chop_prefix ~pre:"** " |> O.get_or ~default:line
-               in
-               match acc with
-               | _, [], _ -> ([], [ chop line ], [])
-               | toks, current_diag, diags
-                 when String.starts_with ~prefix:entry_prefix line ->
-                   ([], [ chop line ], mk_diag toks current_diag :: diags)
-               | _, current_diag, diags
-                 when String.starts_with ~prefix:tokens_prefix line ->
-                   ( S.chop_prefix ~pre:tokens_prefix line
-                     |> Option.get |> S.trim |> S.split ~by:" "
-                     |> L.map (fun tk ->
-                         L.find
-                           (fun { v; _ } -> S.equal v.terminal tk)
-                           _s.tokens),
-                     chop line :: current_diag,
-                     diags )
-               | toks, current_diag, diags ->
-                   (toks, chop line :: current_diag, diags))
-             ([], [], [])
-        |> fun (toks, last, diags) -> mk_diag toks last :: diags)
+        |> fun lines ->
+        List.fold_right
+          (fun line acc ->
+            let chop s =
+              s |> S.chop_prefix ~pre:"** " |> O.get_or ~default:line
+            in
+            match acc with
+            | toks, current_diag, diags
+              when String.starts_with ~prefix:"** Conflict" line ->
+                ([], [], mk_diag toks (chop line :: current_diag) :: diags)
+            | _, current_diag, diags
+              when String.starts_with ~prefix:tokens_prefix line ->
+                ( S.chop_prefix ~pre:tokens_prefix line
+                  |> Option.get |> S.trim |> S.split ~by:" "
+                  |> L.map (fun tk ->
+                      L.find (fun { v; _ } -> S.equal v.terminal tk) _s.tokens),
+                  chop line :: current_diag,
+                  diags )
+            | toks, current_diag, diags ->
+                (toks, chop line :: current_diag, diags))
+          lines ([], [], [])
+        |> fun (_, _, diags) -> diags)
   with _ -> []
 
 let references (state : state) ~uri ~(pos : Position.t) : Location.t list =

--- a/bin/menhir.ml
+++ b/bin/menhir.ml
@@ -350,14 +350,14 @@ let definition (state : state) ~uri ~(pos : Position.t) : Locations.t =
 let completions ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
     ~(word : word option) ~(pos : Position.t) ~(uri : uri)
     ({ grammar; _ } as state : state) : CompletionItem.t list =
-  let pos_inside r = Position.compare_inclusion pos r = `Inside in
-  let ( <|> ) (a : 'a option) (b : 'a option lazy_t) =
-    match (a, b) with
-    | Some a, _ -> Some a
-    | None, (lazy (Some b)) -> Some b
-    | _ -> None
+  let open O in
+  let pos_inside = Position.is_inside pos in
+  let merlin_compls () =
+    (let* word = word in
+     get_merlin_compls ~notify_back ~uri ~pos word)
+    |> get_or ~default:[]
   in
-  let declaration_completions =
+  let declaration_completions () =
     L.find_map
       (fun ({ v; _ } : declaration located) ->
         match v with
@@ -366,33 +366,25 @@ let completions ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
         | DToken (Some (Declared { p; _ }), _, _, _)
         | DParameter { p; _ } ->
             let range = Range.of_lexical_positions p in
-            O.if_
-              (fun _ -> pos_inside range)
-              (O.(
-                 let* word = word in
-                 get_merlin_compls ~notify_back ~uri ~pos word)
-              |> O.get_or ~default:[])
+            if_ (fun _ -> pos_inside range) (merlin_compls ())
         | _ -> None)
       grammar.pg_declarations
   in
   let _postlude =
-    O.(
-      grammar.pg_postlude
-      >|= (fun { p; _ } -> Range.of_lexical_positions p)
-      |> to_list)
+    grammar.pg_postlude
+    >|= (fun { p; _ } -> Range.of_lexical_positions p)
+    |> to_list
   in
   let word_range =
-    O.(
-      let+ { p; _ } = word in
-      p)
+    let+ { p; _ } = word in
+    p
   in
   (* If we are inside a semantic action we shall suggest bound variables, position keywords and OCaml symbols *)
-  let action_completions =
+  let action_completions () =
     L.find_map
       (fun rule ->
         L.find_map
           (fun branch ->
-            let open O in
             let* action_range =
               match branch.pb_action.expr with
               | M.IL.ETextual { p; _ } -> Some (Range.of_lexical_positions p)
@@ -400,37 +392,33 @@ let completions ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
             in
             if_
               (fun _ -> pos_inside action_range)
-              (((let* word = word in
-                 get_merlin_compls ~notify_back ~uri ~pos word)
-               |> O.get_or ~default:[])
-              @ Keywords.position_keywords ?range:word_range ()
-              @
-              let open L in
-              let+ binder, par, _ = branch.pb_producers in
-              let binder =
-                O.(
-                  CCString.chop_prefix ~pre:"_" binder.v
-                  >|= ( ^ ) "$" |> get_or ~default:binder.v)
-              in
-              CompletionItem.create ~kind:Variable
-                ~detail:(string_of_params par) ~label:binder
-                ?textEdit:
-                  O.(
-                    let+ range = word_range in
-                    `TextEdit TextEdit.{ newText = binder; range })
-                ()))
+              (Keywords.position_keywords ?range:word_range ()
+              @ (let open L in
+                 let+ binder, par, _ = branch.pb_producers in
+                 let binder =
+                   O.(
+                     CCString.chop_prefix ~pre:"_" binder.v
+                     >|= ( ^ ) "$" |> get_or ~default:binder.v)
+                 in
+                 CompletionItem.create ~kind:Variable
+                   ~detail:(string_of_params par) ~label:binder
+                   ?textEdit:
+                     O.(
+                       let+ range = word_range in
+                       `TextEdit TextEdit.{ newText = binder; range })
+                   ())
+              @ merlin_compls ()))
           rule.pr_branches)
       grammar.pg_rules
   in
-  let grammar_completions =
-    default_completions ?range:word_range state
+  let grammar_completions () =
+    some
+    @@ default_completions ?range:word_range state
     @ standard_lib_completions
     @ Keywords.declarations ?range:word_range ()
   in
-  declaration_completions
-  <|> lazy action_completions
-  <|> lazy (Some grammar_completions)
-  |> O.get_or ~default:[]
+  declaration_completions () <|> action_completions <|> grammar_completions
+  |> get_or ~default:[]
 
 let prepare_rename (state : state) ~(pos : Position.t) : Range.t option =
   let open O in

--- a/bin/menhir.ml
+++ b/bin/menhir.ml
@@ -17,30 +17,8 @@ type state = {
   symbols : string located list;
 }
 
-let get_conflicts_file ~uri =
-  let module P = Stdune.Path in
-  let module F = Filename in
-  let grammar_path = DocumentUri.to_path uri in
-  let grammar_name = F.basename grammar_path in
-  let grammar_slug = F.remove_extension grammar_name in
-  let open R in
-  let* root_dir, context = get_build_dirs () in
-  let p_root = P.of_string root_dir in
-  let p_context = P.of_string (F.concat root_dir context) in
-  let p_grammar = P.of_string (F.dirname grammar_path) in
-  match P.drop_prefix p_grammar ~prefix:p_root with
-  | None ->
-      Error
-        (spr
-           "No config found for %s. Make sure (menhir (modules .. %s ..)) is \
-            included in the stanza's dune file."
-           grammar_name grammar_slug)
-  | Some rel ->
-      let p_conflicts = P.append_local p_context rel in
-      let conflicts_file =
-        F.concat (P.to_string p_conflicts) (grammar_slug ^ ".conflicts")
-      in
-      Ok conflicts_file
+let get_cmly_file ~uri = fetch_build_dir ~ext:".cmly" uri
+let get_conflicts_file ~uri = fetch_build_dir ~ext:".conflicts" uri
 
 let rec string_of_params : parameter -> string = function
   | M.Syntax.ParamVar p -> p.v
@@ -127,41 +105,6 @@ let load_state_from_contents (file_name : string) (file_contents : string) :
 let standard_lib =
   Standard.menhir_standard_library_grammar |> load_state_from_partial_grammar
   |> R.get_exn
-
-(** If we are inside a semantic action, we shall suggest things relevant to the
-    action: bound variables, position keywords etc. *)
-let completions_for_action ?range:(ro : Range.t option) (pos : Position.t)
-    ({ grammar; _ } : state) : CompletionItem.t list =
-  let comps =
-    L.(
-      let* rule = grammar.pg_rules in
-      let* branch = rule.pr_branches in
-      let branch_range =
-        Range.of_lexical_positions
-        @@
-        match branch.pb_action.expr with
-        | M.IL.ETextual { p; _ } -> p
-        | _ -> branch.pb_position
-      in
-      if Position.compare_inclusion pos branch_range = `Inside then
-        Keywords.position_keywords ?range:ro ()
-        @
-        let+ binder, par, _ = branch.pb_producers in
-        let binder =
-          O.(
-            CCString.chop_prefix ~pre:"_" binder.v
-            >|= ( ^ ) "$" |> get_or ~default:binder.v)
-        in
-        CompletionItem.create ~kind:Variable ~detail:(string_of_params par)
-          ~label:binder
-          ?textEdit:
-            O.(
-              let+ range = ro in
-              `TextEdit TextEdit.{ newText = binder; range })
-          ()
-      else [])
-  in
-  comps
 
 let default_completions ?(range : Range.t option)
     ?(docs : (string, string) Hashtbl.t = Hashtbl.create 0)
@@ -315,9 +258,9 @@ let diagnostics ~(notify_back : notify_back) ~(uri : uri) (_s : state) :
         ~relatedInformation:
           L.(
             let+ tk = toks in
-            log
+            (* log
             @@ spr "token name: %s %s" tk.v.terminal
-                 Range.(of_lexical_positions tk.p |> show);
+                 Range.(of_lexical_positions tk.p |> show); *)
             DiagnosticRelatedInformation.create
               ~location:
                 (Location.create ~uri ~range:(Range.of_lexical_positions tk.p))
@@ -404,39 +347,90 @@ let definition (state : state) ~uri ~(pos : Position.t) : Locations.t =
   |> O.to_list
   |> fun locs -> `Location locs
 
-let completions (state : state) ~(word : word option) ~(pos : Position.t) :
-    CompletionItem.t list =
-  let prelude =
-    L.filter_map
+let completions ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
+    ~(word : word option) ~(pos : Position.t) ~(uri : uri)
+    ({ grammar; _ } as state : state) : CompletionItem.t list =
+  let pos_inside r = Position.compare_inclusion pos r = `Inside in
+  let ( <|> ) (a : 'a option) (b : 'a option lazy_t) =
+    match (a, b) with
+    | Some a, _ -> Some a
+    | None, (lazy (Some b)) -> Some b
+    | _ -> None
+  in
+  let declaration_completions =
+    L.find_map
       (fun ({ v; _ } : declaration located) ->
         match v with
-        | DCode { p; _ } -> Some (Range.of_lexical_positions p)
+        | DCode { p; _ }
+        | DType (Declared { p; _ }, _)
+        | DToken (Some (Declared { p; _ }), _, _, _)
+        | DParameter { p; _ } ->
+            let range = Range.of_lexical_positions p in
+            O.if_
+              (fun _ -> pos_inside range)
+              (O.(
+                 let* word = word in
+                 get_merlin_compls ~notify_back ~uri ~pos word)
+              |> O.get_or ~default:[])
         | _ -> None)
-      state.grammar.pg_declarations
+      grammar.pg_declarations
   in
-  let postlude =
+  let _postlude =
     O.(
-      state.grammar.pg_postlude
+      grammar.pg_postlude
       >|= (fun { p; _ } -> Range.of_lexical_positions p)
       |> to_list)
   in
-  if
-    L.exists
-      (fun r -> Position.compare_inclusion pos r = `Inside)
-      (prelude @ postlude)
-  then []
-  else
-    let range =
-      O.(
-        let+ { p; _ } = word in
-        p)
-    in
-    match completions_for_action ?range pos state with
-    | [] ->
-        default_completions ?range state
-        @ standard_lib_completions
-        @ Keywords.declarations ?range ()
-    | l -> l
+  let word_range =
+    O.(
+      let+ { p; _ } = word in
+      p)
+  in
+  (* If we are inside a semantic action we shall suggest bound variables, position keywords and OCaml symbols *)
+  let action_completions =
+    L.find_map
+      (fun rule ->
+        L.find_map
+          (fun branch ->
+            let open O in
+            let* action_range =
+              match branch.pb_action.expr with
+              | M.IL.ETextual { p; _ } -> Some (Range.of_lexical_positions p)
+              | _ -> None
+            in
+            if_
+              (fun _ -> pos_inside action_range)
+              (((let* word = word in
+                 get_merlin_compls ~notify_back ~uri ~pos word)
+               |> O.get_or ~default:[])
+              @ Keywords.position_keywords ?range:word_range ()
+              @
+              let open L in
+              let+ binder, par, _ = branch.pb_producers in
+              let binder =
+                O.(
+                  CCString.chop_prefix ~pre:"_" binder.v
+                  >|= ( ^ ) "$" |> get_or ~default:binder.v)
+              in
+              CompletionItem.create ~kind:Variable
+                ~detail:(string_of_params par) ~label:binder
+                ?textEdit:
+                  O.(
+                    let+ range = word_range in
+                    `TextEdit TextEdit.{ newText = binder; range })
+                ()))
+          rule.pr_branches)
+      grammar.pg_rules
+  in
+  let grammar_completions =
+    default_completions ?range:word_range state
+    @ standard_lib_completions
+    @ Keywords.declarations ?range:word_range ()
+  in
+  declaration_completions
+  <|> lazy action_completions
+  <|> lazy (Some grammar_completions)
+  |> O.get_or ~default:[]
 
 let prepare_rename (state : state) ~(pos : Position.t) : Range.t option =
   let open O in

--- a/bin/ocamllex.ml
+++ b/bin/ocamllex.ml
@@ -253,53 +253,67 @@ and …|};
         ] );
     ]
 
-let completions_for_action (pos : Position.t) ({ grammar; _ } : state) =
-  (* in actions, we want to suggest `lexbuf`, the variables bound with `as` in the current clause and the other lexer entrypoints *)
-  L.(
-    let* rule = grammar.entrypoints in
-    let* regexp, r = rule.clauses in
-    let range = Range.of_lexical_positions r in
-    if Position.compare_inclusion pos range = `Inside then
-      (let+ arg = rule.args in
-       CompletionItem.create ~kind:Value ~label:arg.v ())
-      @ (let+ entry = grammar.entrypoints in
-         CompletionItem.create ~kind:Function ~label:entry.name.v ())
-      @ (let+ binder = regexp_bindings regexp in
-         CompletionItem.create ~kind:Value ~label:binder.v ())
-      @ compile_completions ~kind:Value
-          [
-            ( "lexbuf",
-              None,
-              None,
-              [
-                md_fenced "lexbuf : Lexing.lexbuf";
-                "The current lexer buffer.";
-                "Can be used in conjunction with the operations on lexer \
-                 buffers provided by the `Lexing` standard library module.";
-                manual_ref "ss:ocamllex-actions";
-              ] );
-          ]
-    else [])
-
-let completions ({ grammar = { header; trailer; _ }; _ } as state : state)
-    ~(pos : Position.t) : CompletionItem.t list =
+let completions ({ grammar = { header; trailer; _ } as grammar; _ } : state)
+    ~(notify_back : Linol_lwt.Jsonrpc2.notify_back) ~(word : word option)
+    ~(pos : Position.t) ~(uri : uri) : CompletionItem.t list =
+  let open O in
+  let pos_inside = Position.is_inside pos in
   let header = Range.of_lexical_positions header in
   let trailer = Range.of_lexical_positions trailer in
-  if
-    Position.(
-      compare_inclusion pos header = `Inside
-      || compare_inclusion pos trailer = `Inside)
-  then []
-  else
-    match completions_for_action pos state with
-    | [] ->
-        regex_operator_completions @ keyword_completions
-        @ L.map
-            (fun (name, _) ->
-              (* let _range = Range.of_lexical_positions p in *)
-              CompletionItem.create ~kind:Property ~label:name.v ())
-            state.grammar.named_regexps
-    | l -> l
+  let merlin_compls () =
+    (let* word = word in
+     get_merlin_compls ~notify_back ~uri ~pos word)
+    |> get_or ~default:[]
+  in
+  let header_completions () =
+    if_ (fun _ -> pos_inside header || pos_inside trailer) (merlin_compls ())
+  in
+  (* Inside actions we shall suggest `lexbuf`, the variables bound with `as` in the current clause, the lexer entrypoints, and OCaml symbols *)
+  let action_completions () =
+    L.find_map
+      (fun (rule : _ Syntax.entry) ->
+        L.find_map
+          (fun (regexp, r) ->
+            let range = Range.of_lexical_positions r in
+            if_
+              (fun _ -> pos_inside range)
+              (L.(
+                 let+ arg = rule.args in
+                 CompletionItem.create ~kind:Value ~label:arg.v ())
+              @ L.(
+                  let+ entry = grammar.entrypoints in
+                  CompletionItem.create ~kind:Function ~label:entry.name.v ())
+              @ L.(
+                  let+ binder = regexp_bindings regexp in
+                  CompletionItem.create ~kind:Value ~label:binder.v ())
+              @ compile_completions ~kind:Value
+                  [
+                    ( "lexbuf",
+                      None,
+                      None,
+                      [
+                        md_fenced "Lexing.lexbuf";
+                        "The current lexer buffer.";
+                        "Can be used in conjunction with the operations on \
+                         lexer buffers provided by the `Lexing` standard \
+                         library module.";
+                        manual_ref "ss:ocamllex-actions";
+                      ] );
+                  ]
+              @ merlin_compls ()))
+          rule.clauses)
+      grammar.entrypoints
+  in
+  let lexer_completions =
+    regex_operator_completions @ keyword_completions
+    @ L.map
+        (fun (name, _) ->
+          (* let _range = Range.of_lexical_positions p in *)
+          CompletionItem.create ~kind:Property ~label:name.v ())
+        grammar.named_regexps
+  in
+  header_completions () <|> action_completions
+  |> get_or ~default:lexer_completions
 
 let print_symbols ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
     (state : state) =

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -3,7 +3,19 @@ module MR = MenhirSyntax.Range
 module L = CCList
 module P = CCParse
 module LA = L.Assoc
-module O = CCOption
+
+module O = struct
+  include CCOption
+
+  (* map_none *)
+  let ( let- ) (a : 'a option) (f : unit -> 'b) : 'b option =
+    match a with None -> Some (f ()) | Some _ -> None
+
+  (* bind_none *)
+  let ( let*- ) (a : 'a option) (f : unit -> 'b option) : 'b option =
+    match a with None -> f () | Some _ -> None
+end
+
 module R = CCResult
 module A = CCArray
 module F = CCFun
@@ -14,10 +26,11 @@ module Lsp = Linol_lsp.Lsp
 module Loc = M.Located
 module Log = (val Logs.src_log Linol.logs_src)
 include Lsp.Types
+module Text_document = Lsp.Text_document
 
 type notify_back = Linol_lwt.Jsonrpc2.notify_back
 type uri = Lsp.Types.DocumentUri.t
-type word = { v : string; p : Range.t }
+type word = { v : string; p : Range.t; td : Text_document.t }
 
 let pr = Pr.printf
 let spr = Pr.sprintf
@@ -231,6 +244,8 @@ let in_build_dir ?(ext : string option) uri =
 module MK = Merlin_kernel
 module QP = Query_protocol
 
+let merlin_configs : (uri, MK.Mconfig.t) Hashtbl.t = Hashtbl.create 42
+
 let get_merlin_config ~(notify_back : notify_back) ~(uri : uri) =
   let path = DocumentUri.to_path uri in
   let dir = Filename.dirname path in
@@ -251,14 +266,45 @@ let get_merlin_config ~(notify_back : notify_back) ~(uri : uri) =
   in
   MK.Mconfig.normalize { MK.Mconfig.initial with merlin }
 
-let get_merlin_compls ~(doc : Lsp.Text_document.t) ~(notify_back : notify_back)
-    ~(uri : uri) ~(pos : Position.t) prefix =
+let find_merlin_config ~notify_back ~uri =
+  let open O in
+  let*- _ = Hashtbl.find_opt merlin_configs uri in
+  log_info ~notify_back @@ spr "couldn't find merlin config for %s, generating new one" (DocumentUri.to_path uri);
+  let+ config = get_merlin_config ~notify_back ~uri in
+  Hashtbl.add merlin_configs uri config;
+  config
+
+(** Source: ocaml-lsp/ocaml-lsp-server/src/compl.ml *)
+let completion_kind kind : CompletionItemKind.t option =
+  match kind with
+  | `Value -> Some Value
+  | `Variant -> Some EnumMember
+  | `Label -> Some Field
+  | `Module -> Some Module
+  | `Modtype -> Some Interface
+  | `MethodCall -> Some Method
+  | `Keyword -> Some Keyword
+  | `Constructor -> Some Constructor
+  | `Type -> Some TypeParameter
+
+let get_merlin_compls ~(notify_back : notify_back) ~(uri : uri)
+    ~(pos : Position.t) (prefix : word) =
   let open O in
   let+ config = get_merlin_config ~notify_back ~uri in
-  let source = MK.Msource.make (Lsp.Text_document.text doc) in
+  let source = MK.Msource.make (Text_document.text prefix.td) in
   let pipeline = MK.Mpipeline.make config source in
-  let logical_pos = Position.logical pos in
-  let query =
-    Query_protocol.Complete_prefix (prefix, logical_pos, [], false, true)
-  in
-  Query_commands.dispatch pipeline query
+  MK.Mpipeline.with_pipeline pipeline (fun _ ->
+      let logical_pos = Position.logical pos in
+      let query =
+        Query_protocol.Complete_prefix (prefix.v, logical_pos, [], false, true)
+      in
+      let compls = Query_commands.dispatch pipeline query in
+      (* from ocaml-lsp/ocaml-lsp-server/src/compl.ml *)
+      let sortText_of_index idx = Printf.sprintf "%04d" idx in
+      L.mapi
+        (fun idx QP.Compl.{ name; kind; desc; _ } ->
+          CompletionItem.create ~label:name ?kind:(completion_kind kind)
+            ~sortText:(sortText_of_index idx) ~detail:desc
+            ~textEdit:(`TextEdit { newText = name; range = prefix.p })
+            ())
+        compls.entries)

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -3,19 +3,7 @@ module MR = MenhirSyntax.Range
 module L = CCList
 module P = CCParse
 module LA = L.Assoc
-
-module O = struct
-  include CCOption
-
-  (* map_none *)
-  let ( let- ) (a : 'a option) (f : unit -> 'b) : 'b option =
-    match a with None -> Some (f ()) | Some _ -> None
-
-  (* bind_none *)
-  let ( let*- ) (a : 'a option) (f : unit -> 'b option) : 'b option =
-    match a with None -> f () | Some _ -> None
-end
-
+module O = CCOption
 module R = CCResult
 module A = CCArray
 module F = CCFun
@@ -39,7 +27,9 @@ let epr = Pr.eprintf
 let log_info ~(notify_back : notify_back) s =
   s |> notify_back#send_log_msg ~type_:Info |> ignore
 
-(** Adapted from https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/position.ml *)
+(** Adapted from
+    https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/position.ml
+*)
 module Position = struct
   include Lsp.Types.Position
 
@@ -86,7 +76,9 @@ module Position = struct
     `Logical (line, col)
 end
 
-(** Adapted from https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/range.ml *)
+(** Adapted from
+    https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/range.ml
+*)
 module Range = struct
   include Lsp.Types.Range
 
@@ -214,10 +206,10 @@ let get_build_dirs uri =
 
     [/home/foo/menhir-lsp/test/calc.mly]
 
-    then [in_build_dir ~ext:".conflicts" uri] is
+    then [fetch_build_dir ~ext:".conflicts" uri] is
 
     [/home/foo/menhir-lsp/_build/default/test/calc.conflicts] *)
-let in_build_dir ?(ext : string option) uri =
+let fetch_build_dir ?(ext : string option) uri =
   let module P = Stdune.Path in
   let module F = Filename in
   let s_path = DocumentUri.to_path uri in
@@ -268,13 +260,15 @@ let get_merlin_config ~(notify_back : notify_back) ~(uri : uri) =
 
 let find_merlin_config ~notify_back ~uri =
   let open O in
-  let*- _ = Hashtbl.find_opt merlin_configs uri in
-  log_info ~notify_back
-  @@ spr "couldn't find merlin config for %s, generating new one"
-       (DocumentUri.to_path uri);
-  let+ config = get_merlin_config ~notify_back ~uri in
-  Hashtbl.add merlin_configs uri config;
-  config
+  match Hashtbl.find_opt merlin_configs uri with
+  | None ->
+      log_info ~notify_back
+      @@ spr "couldn't find merlin config for %s, generating new one"
+           (DocumentUri.to_path uri);
+      let+ config = get_merlin_config ~notify_back ~uri in
+      Hashtbl.add merlin_configs uri config;
+      config
+  | o -> o
 
 (** https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/compl.ml
 *)
@@ -314,10 +308,14 @@ let get_merlin_compls ~(notify_back : notify_back) ~(uri : uri)
          { Range.start; end_ = pos })
         |> get_or ~default:prefix.p
       in
-      L.mapi
-        (fun idx QP.Compl.{ name; kind; desc; _ } ->
-          CompletionItem.create ~label:name ?kind:(completion_kind kind)
-            ~sortText:(sortText_of_index idx) ~detail:desc
-            ~textEdit:(`TextEdit { newText = name; range })
-            ())
-        compls.entries)
+      let compls =
+        L.mapi
+          (fun idx QP.Compl.{ name; kind; desc; _ } ->
+            CompletionItem.create ~label:name ?kind:(completion_kind kind)
+              ~sortText:(sortText_of_index idx) ~detail:desc
+              ~textEdit:(`TextEdit { newText = name; range })
+              ())
+          compls.entries
+      in
+      log_info ~notify_back @@ spr "# merlin completions: %d" (L.length compls);
+      compls)

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -172,23 +172,93 @@ let compile_completions ?(range : Range.t option) ~(kind : CompletionItemKind.t)
                       ~value:(String.concat "\n\n" docs))))
         ())
 
-let get_build_dirs () =
-  try
+let build_dirs : (uri, string * string) Hashtbl.t = Hashtbl.create 42
+
+let get_build_dirs uri =
+  let open R in
+  let f _ =
     let s =
       let inp = Unix.open_process_in "dune describe workspace" in
       let s = CCSexp.parse_chan inp in
       In_channel.close inp;
       s
     in
-    let open R in
     match s with
     | Ok
         (`List
            (`List [ `Atom "root"; `Atom root_dir ]
            :: `List [ `Atom "build_context"; `Atom context ]
            :: _)) ->
-        Ok (root_dir, context)
-    | _ -> Error "dune describe output did not match expected pattern"
+        (root_dir, context)
+    | _ -> failwith "bad pattern"
+  in
+  try CCHashtbl.get_or_add build_dirs ~k:uri ~f |> R.return
   with _ ->
-    (* Can fail due to 'A running dune (pid: ..) instance has locked the build directory.') *)
-    Error "dune describe failed"
+    (* May fail due to 'A running dune (pid: ..) instance has locked the build directory.') *)
+    Error "Failed to read dune describe's output"
+
+(** e.g. if [uri] is
+
+    [/home/foo/menhir-lsp/test/calc.mly]
+
+    then [in_build_dir ~ext:".conflicts" uri] is
+
+    [/home/foo/menhir-lsp/_build/default/test/calc.conflicts] *)
+let in_build_dir ?(ext : string option) uri =
+  let module P = Stdune.Path in
+  let module F = Filename in
+  let s_path = DocumentUri.to_path uri in
+  let s_name = F.basename s_path in
+  let s_slug = F.remove_extension s_name in
+  let s_ext = O.get_or ~default:(F.extension s_name) ext in
+  let open R in
+  let* root, ctx = get_build_dirs uri in
+  let p_root = P.of_string root in
+  let p_dir = P.of_string (F.dirname s_path) in
+  match P.drop_prefix p_dir ~prefix:p_root with
+  | None ->
+      Error
+        (spr
+           "No config found for %s. Make sure (menhir (modules .. %s ..)) is \
+            included in the stanza's dune file."
+           s_name s_slug)
+  | Some p_rel ->
+      let p_ctx = P.of_string (F.concat root ctx) in
+      let p_res = P.append_local p_ctx p_rel in
+      let res = F.concat (P.to_string p_res) (s_slug ^ s_ext) in
+      Ok res
+
+module MK = Merlin_kernel
+module QP = Query_protocol
+
+let get_merlin_config ~(notify_back : notify_back) ~(uri : uri) =
+  let path = DocumentUri.to_path uri in
+  let dir = Filename.dirname path in
+  let open O in
+  let+ ctx, config_path = MK.Mconfig_dot.find_project_context dir in
+  let dot, failures = MK.Mconfig_dot.get_config ctx path in
+  let concat = String.concat ", " in
+  log_info ~notify_back
+  @@ spr
+       {|Search result for Merlin config of %s:
+  Errors: %s
+  Source path: %s
+  Build path: %s|}
+       path (concat failures) (concat dot.source_path) (concat dot.build_path);
+  let merlin =
+    MK.Mconfig.merge_merlin_config dot MK.Mconfig.initial.merlin ~failures
+      ~config_path
+  in
+  MK.Mconfig.normalize { MK.Mconfig.initial with merlin }
+
+let get_merlin_compls ~(doc : Lsp.Text_document.t) ~(notify_back : notify_back)
+    ~(uri : uri) ~(pos : Position.t) prefix =
+  let open O in
+  let+ config = get_merlin_config ~notify_back ~uri in
+  let source = MK.Msource.make (Lsp.Text_document.text doc) in
+  let pipeline = MK.Mpipeline.make config source in
+  let logical_pos = Position.logical pos in
+  let query =
+    Query_protocol.Complete_prefix (prefix, logical_pos, [], false, true)
+  in
+  Query_commands.dispatch pipeline query

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -15,12 +15,16 @@ module Loc = M.Located
 module Log = (val Logs.src_log Linol.logs_src)
 include Lsp.Types
 
+type notify_back = Linol_lwt.Jsonrpc2.notify_back
 type uri = Lsp.Types.DocumentUri.t
 type word = { v : string; p : Range.t }
 
 let pr = Pr.printf
 let spr = Pr.sprintf
 let epr = Pr.eprintf
+
+let log_info ~(notify_back : notify_back) s =
+  s |> notify_back#send_log_msg ~type_:Info |> ignore
 
 (** Adapted from ocaml-lsp/ocaml-lsp-server/src/position.ml *)
 module Position = struct
@@ -167,3 +171,24 @@ let compile_completions ?(range : Range.t option) ~(kind : CompletionItemKind.t)
                    (MarkupContent.create ~kind:Markdown
                       ~value:(String.concat "\n\n" docs))))
         ())
+
+let get_build_dirs () =
+  try
+    let s =
+      let inp = Unix.open_process_in "dune describe workspace" in
+      let s = CCSexp.parse_chan inp in
+      In_channel.close inp;
+      s
+    in
+    let open R in
+    match s with
+    | Ok
+        (`List
+           (`List [ `Atom "root"; `Atom root_dir ]
+           :: `List [ `Atom "build_context"; `Atom context ]
+           :: _)) ->
+        Ok (root_dir, context)
+    | _ -> Error "dune describe output did not match expected pattern"
+  with _ ->
+    (* Can fail due to 'A running dune (pid: ..) instance has locked the build directory.') *)
+    Error "dune describe failed"

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -3,7 +3,14 @@ module MR = MenhirSyntax.Range
 module L = CCList
 module P = CCParse
 module LA = L.Assoc
-module O = CCOption
+
+module O = struct
+  include CCOption
+
+  let ( <|> ) (a : 'a option) (b : unit -> 'a option) =
+    match (a, b) with Some a, _ -> Some a | None, f -> f ()
+end
+
 module R = CCResult
 module A = CCArray
 module F = CCFun
@@ -69,6 +76,8 @@ module Position = struct
     | Gt, Gt -> `Outside (abs (r.end_ - t))
     | Eq, Lt | Gt, Eq | Eq, Eq | Gt, Lt -> `Inside
     | Eq, Gt | Lt, Eq | Lt, Gt -> assert false (* uncanny *)
+
+  let is_inside (t : t) r = compare_inclusion t r = `Inside
 
   let logical position =
     let line = position.line + 1 in

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -39,7 +39,7 @@ let epr = Pr.eprintf
 let log_info ~(notify_back : notify_back) s =
   s |> notify_back#send_log_msg ~type_:Info |> ignore
 
-(** Adapted from ocaml-lsp/ocaml-lsp-server/src/position.ml *)
+(** Adapted from https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/position.ml *)
 module Position = struct
   include Lsp.Types.Position
 
@@ -86,7 +86,7 @@ module Position = struct
     `Logical (line, col)
 end
 
-(** Adapted from ocaml-lsp/ocaml-lsp-server/src/range.ml *)
+(** Adapted from https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/range.ml *)
 module Range = struct
   include Lsp.Types.Range
 
@@ -269,12 +269,15 @@ let get_merlin_config ~(notify_back : notify_back) ~(uri : uri) =
 let find_merlin_config ~notify_back ~uri =
   let open O in
   let*- _ = Hashtbl.find_opt merlin_configs uri in
-  log_info ~notify_back @@ spr "couldn't find merlin config for %s, generating new one" (DocumentUri.to_path uri);
+  log_info ~notify_back
+  @@ spr "couldn't find merlin config for %s, generating new one"
+       (DocumentUri.to_path uri);
   let+ config = get_merlin_config ~notify_back ~uri in
   Hashtbl.add merlin_configs uri config;
   config
 
-(** Source: ocaml-lsp/ocaml-lsp-server/src/compl.ml *)
+(** https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/compl.ml
+*)
 let completion_kind kind : CompletionItemKind.t option =
   match kind with
   | `Value -> Some Value
@@ -299,12 +302,22 @@ let get_merlin_compls ~(notify_back : notify_back) ~(uri : uri)
         Query_protocol.Complete_prefix (prefix.v, logical_pos, [], false, true)
       in
       let compls = Query_commands.dispatch pipeline query in
-      (* from ocaml-lsp/ocaml-lsp-server/src/compl.ml *)
       let sortText_of_index idx = Printf.sprintf "%04d" idx in
+      (* Merlin wants the completion prefix to include the fully qualified module path,
+      but the TextEdit range must not extend before the cursor position, otherwise the completion won't show.
+      Reference: https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/compl.ml *)
+      let range =
+        (let+ prefix = String.split_on_char '.' prefix.v |> L.last_opt in
+         let len = String.length prefix in
+         let character = pos.character - len in
+         let start = { pos with character } in
+         { Range.start; end_ = pos })
+        |> get_or ~default:prefix.p
+      in
       L.mapi
         (fun idx QP.Compl.{ name; kind; desc; _ } ->
           CompletionItem.create ~label:name ?kind:(completion_kind kind)
             ~sortText:(sortText_of_index idx) ~detail:desc
-            ~textEdit:(`TextEdit { newText = name; range = prefix.p })
+            ~textEdit:(`TextEdit { newText = name; range })
             ())
         compls.entries)


### PR DESCRIPTION
The server now provides completions for OCaml symbols in grammars and lexers. These completions are suggested inside semantic actions and a few other places in Menhir grammars, for example inside the angle brackets of `%start`, `%type` and `%token` declarations, e.g.:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/d5ae4c36-9a11-4ac4-8084-c1d5f99f4418" />


The completions are calculated by [Merlin](https://ocaml.org/p/merlin-lib/latest) and are available only when the project is built with dune. Sadly they don't seem to pick up modules `open`ed in the prelude of the grammar, probably due to how the grammar is transpiled to OCaml code, but I'm pretty happy with this nonetheless.

Closes #2.
