### PR TITLE
Fetch diagnostics from .conflicts file

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -127,6 +127,46 @@ class lsp_server =
                { prepareProvider = Some true; workDoneProgress = None });
       }
 
+    method! on_notification_unhandled ~notify_back =
+      function
+      | DidChangeWatchedFiles params ->
+          let open R in
+          let module P = Stdune.Path in
+          let module F = Filename in
+          (let+ root, ctx = get_build_dir () in
+           L.map
+             (fun ch ->
+               let s_path = ch.FileEvent.uri |> DocumentUri.to_path in
+               log_info ~notify_back @@ spr "Watched file change: %s" s_path;
+               let p_path = P.of_string s_path in
+               let p_build = P.of_string F.(concat root ctx) in
+               match P.drop_prefix p_path ~prefix:p_build with
+               | None -> ()
+               | Some p ->
+                   let uri =
+                     DocumentUri.of_path
+                       F.(
+                         concat root
+                           ( P.Local.to_string p |> F.remove_extension
+                           |> fun s -> s ^ ".mly" ))
+                   in
+
+                   log_info ~notify_back
+                   @@ spr "reconstructed source path: %s"
+                        (DocumentUri.to_path uri);
+                   (let open O in
+                    let+ state = Hashtbl.find_opt mly_buffers uri in
+                    let diags = Mly.diagnostics ~notify_back ~uri state in
+                    log_info ~notify_back
+                    @@ spr "# conflicts: %d" (L.length diags);
+                    notify_back#send_diagnostic diags)
+                   (* doesn't work :/ *)
+                   |> ignore)
+             params.changes)
+          |> ignore;
+          Lwt.return ()
+      | _ -> Lwt.return ()
+
     method! on_request_unhandled : type r.
         notify_back:Linol_lwt.Jsonrpc2.notify_back ->
         id:Linol_jsonrpc.Jsonrpc.Id.t ->
@@ -209,7 +249,7 @@ class lsp_server =
        - return the diagnostics from the new state
     *)
     method private _on_doc ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
-        (uri : uri) (contents : string) =
+        (uri : uri) (contents : string) : unit Lwt.t =
       let filename = DocumentUri.to_path uri in
       notify_back#send_log_msg ~type_:Info
         (spr "Processing document %s" filename);%lwt
@@ -228,9 +268,7 @@ class lsp_server =
       (* consider matching on TextDocumentItem.languageId *)
       match Filename.extension filename with
       | ".mll" -> go mll_buffers Mll.load_state_from_contents Mll.diagnostics
-      | ".mly" ->
-          go mly_buffers Mly.load_state_from_contents
-            (Mly.diagnostics ~notify_back ~uri)
+      | ".mly" -> go mly_buffers Mly.load_state_from_contents (fun _ -> [])
       | ext ->
           notify_back#send_log_msg ~type_:Error
           @@ spr "Unhandled document type: %s" ext

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -94,8 +94,7 @@ class lsp_server =
             ~mly_handler:(Mly.completions ~notify_back ~pos ~uri ~word)
           |> get_or ~default:[]
         in
-        log_info ~notify_back
-          (spr "# completions: %d" (L.length grammar_compls));
+        log_info ~notify_back "# completions: %d" (L.length grammar_compls);
         `List grammar_compls |> some |> Lwt.return
 
     method! config_symbol = Some (`Bool true)
@@ -137,7 +136,7 @@ class lsp_server =
            L.filter_map
              (fun FileEvent.{ uri; _ } ->
                let s_path = Uri.to_path uri in
-               log_info ~notify_back @@ spr "Watched file changed: %s" s_path;
+               log_info ~notify_back "Watched file changed: %s" s_path;
                let p_path = P.of_string s_path in
                let p_build = P.of_string F.(concat root ctx) in
                let open O in
@@ -149,18 +148,12 @@ class lsp_server =
                        ((P.Local.to_string p_source |> remove_extension)
                        ^ ".mly"))
                in
-               log_info ~notify_back
-               @@ spr "Reconstructed source path: %s" (Uri.to_path uri);
+               log_info ~notify_back "Reconstructed source path: %s"
+                 (Uri.to_path uri);
                let+ state = Hashtbl.find_opt mly_buffers uri in
                let diags = Mly.diagnostics ~notify_back ~uri state in
-               log_info ~notify_back @@ spr "# conflicts: %d" (L.length diags);
-               log_info ~notify_back
-               @@ spr "ONH notify_back#uri: %s"
-                    (notify_back#get_uri |> O.map_or Uri.to_string ~default:"");
+               log_info ~notify_back "# conflicts: %d" (L.length diags);
                notify_back#set_uri uri;
-               log_info ~notify_back
-               @@ spr "after setting ONH notify_back#uri: %s"
-                    (notify_back#get_uri |> O.map_or Uri.to_string ~default:"");
                notify_back#send_diagnostic diags)
              params.changes)
           |> ignore;
@@ -179,14 +172,13 @@ class lsp_server =
             self#_on_req_prepare_rename ~notify_back ~id ~uri:r.textDocument.uri
               ~pos:r.position
         | Lsp.Client_request.TextDocumentRename (r : RenameParams.t) ->
-            log_info ~notify_back
-              (spr "Requested rename at position: %s" (Position.show r.position));
+            log_info ~notify_back "Requested rename at position: %s"
+              (Position.show r.position);
             self#_on_req_rename ~notify_back r.newName ~pos:r.position ~id
               ~uri:r.textDocument.uri
         | Lsp.Client_request.TextDocumentReferences (r : ReferenceParams.t) ->
-            log_info ~notify_back
-              (spr "Requested references at position: %s"
-                 (Position.show r.position));
+            log_info ~notify_back "Requested references at position: %s"
+              (Position.show r.position);
             self#_on_req_references ~notify_back ~id ~pos:r.position
               ~uri:r.textDocument.uri
         | _ -> Lwt.fail_with "Unhandled request type"
@@ -214,8 +206,8 @@ class lsp_server =
     method! on_req_definition =
       fun ~notify_back ~id:_ ~uri ~pos ~workDoneToken:_ ~partialResultToken:_
           _doc_state ->
-        log_info ~notify_back
-          (spr "Requested definition at pos %s" (Position.show pos));
+        log_info ~notify_back "Requested definition at pos %s"
+          (Position.show pos);
         self#_dispatch uri ~notify_back ~mly_handler:(Mly.definition ~uri ~pos)
           ~mll_handler:(Mll.definition ~uri ~pos)
         |> Lwt.return
@@ -251,7 +243,7 @@ class lsp_server =
     method private _on_doc ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
         (uri : uri) (contents : string) : unit Lwt.t =
       let filename = DocumentUri.to_path uri in
-      log_info ~notify_back (spr "Processing document %s" filename);
+      log_info ~notify_back "Processing document %s" filename;
       let go buffers loader diagnose =
         let new_state, new_diags =
           match loader filename contents with
@@ -261,9 +253,6 @@ class lsp_server =
           | Error diags -> (Hashtbl.find_opt buffers uri, diags)
         in
         (* diagnoses for the new state (empty) *)
-        log_info ~notify_back
-        @@ spr "notify_back#uri: %s"
-             (notify_back#get_uri |> O.map_or Uri.to_string ~default:"");
         let diags = O.map_or ~default:[] diagnose new_state in
         notify_back#send_diagnostic (diags @ new_diags)
       in
@@ -282,7 +271,7 @@ class lsp_server =
     method on_notif_doc_did_open ~notify_back d ~content : unit Linol_lwt.t =
       get_build_dir () |> ignore;
       find_merlin_config ~notify_back ~uri:d.uri |> ignore;
-      log_info ~notify_back (spr "Language id: %s" d.languageId);
+      log_info ~notify_back "Language id: %s" d.languageId;
       self#_on_doc ~notify_back d.uri content
 
     (* Similarly, we also override the [on_notify_doc_did_change] method that will be called

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -134,34 +134,34 @@ class lsp_server =
           let module P = Stdune.Path in
           let module F = Filename in
           (let+ root, ctx = get_build_dir () in
-           L.map
-             (fun ch ->
-               let s_path = ch.FileEvent.uri |> DocumentUri.to_path in
-               log_info ~notify_back @@ spr "Watched file change: %s" s_path;
+           L.filter_map
+             (fun FileEvent.{ uri; _ } ->
+               let s_path = Uri.to_path uri in
+               log_info ~notify_back @@ spr "Watched file changed: %s" s_path;
                let p_path = P.of_string s_path in
                let p_build = P.of_string F.(concat root ctx) in
-               match P.drop_prefix p_path ~prefix:p_build with
-               | None -> ()
-               | Some p ->
-                   let uri =
-                     DocumentUri.of_path
-                       F.(
-                         concat root
-                           ( P.Local.to_string p |> F.remove_extension
-                           |> fun s -> s ^ ".mly" ))
-                   in
-
-                   log_info ~notify_back
-                   @@ spr "reconstructed source path: %s"
-                        (DocumentUri.to_path uri);
-                   (let open O in
-                    let+ state = Hashtbl.find_opt mly_buffers uri in
-                    let diags = Mly.diagnostics ~notify_back ~uri state in
-                    log_info ~notify_back
-                    @@ spr "# conflicts: %d" (L.length diags);
-                    notify_back#send_diagnostic diags)
-                   (* doesn't work :/ *)
-                   |> ignore)
+               let open O in
+               let* p_source = P.drop_prefix p_path ~prefix:p_build in
+               let uri =
+                 Uri.of_path
+                   F.(
+                     concat root
+                       ((P.Local.to_string p_source |> remove_extension)
+                       ^ ".mly"))
+               in
+               log_info ~notify_back
+               @@ spr "Reconstructed source path: %s" (Uri.to_path uri);
+               let+ state = Hashtbl.find_opt mly_buffers uri in
+               let diags = Mly.diagnostics ~notify_back ~uri state in
+               log_info ~notify_back @@ spr "# conflicts: %d" (L.length diags);
+               log_info ~notify_back
+               @@ spr "ONH notify_back#uri: %s"
+                    (notify_back#get_uri |> O.map_or Uri.to_string ~default:"");
+               notify_back#set_uri uri;
+               log_info ~notify_back
+               @@ spr "after setting ONH notify_back#uri: %s"
+                    (notify_back#get_uri |> O.map_or Uri.to_string ~default:"");
+               notify_back#send_diagnostic diags)
              params.changes)
           |> ignore;
           Lwt.return ()
@@ -179,14 +179,14 @@ class lsp_server =
             self#_on_req_prepare_rename ~notify_back ~id ~uri:r.textDocument.uri
               ~pos:r.position
         | Lsp.Client_request.TextDocumentRename (r : RenameParams.t) ->
-            notify_back#send_log_msg ~type_:Info
-              (spr "Requested rename at position: %s" (Position.show r.position));%lwt
+            log_info ~notify_back
+              (spr "Requested rename at position: %s" (Position.show r.position));
             self#_on_req_rename ~notify_back r.newName ~pos:r.position ~id
               ~uri:r.textDocument.uri
         | Lsp.Client_request.TextDocumentReferences (r : ReferenceParams.t) ->
-            notify_back#send_log_msg ~type_:Info
+            log_info ~notify_back
               (spr "Requested references at position: %s"
-                 (Position.show r.position));%lwt
+                 (Position.show r.position));
             self#_on_req_references ~notify_back ~id ~pos:r.position
               ~uri:r.textDocument.uri
         | _ -> Lwt.fail_with "Unhandled request type"
@@ -214,8 +214,8 @@ class lsp_server =
     method! on_req_definition =
       fun ~notify_back ~id:_ ~uri ~pos ~workDoneToken:_ ~partialResultToken:_
           _doc_state ->
-        notify_back#send_log_msg ~type_:Info
-          (spr "Requested definition at pos %s" (Position.show pos));%lwt
+        log_info ~notify_back
+          (spr "Requested definition at pos %s" (Position.show pos));
         self#_dispatch uri ~notify_back ~mly_handler:(Mly.definition ~uri ~pos)
           ~mll_handler:(Mll.definition ~uri ~pos)
         |> Lwt.return
@@ -251,8 +251,7 @@ class lsp_server =
     method private _on_doc ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
         (uri : uri) (contents : string) : unit Lwt.t =
       let filename = DocumentUri.to_path uri in
-      notify_back#send_log_msg ~type_:Info
-        (spr "Processing document %s" filename);%lwt
+      log_info ~notify_back (spr "Processing document %s" filename);
       let go buffers loader diagnose =
         let new_state, new_diags =
           match loader filename contents with
@@ -262,13 +261,18 @@ class lsp_server =
           | Error diags -> (Hashtbl.find_opt buffers uri, diags)
         in
         (* diagnoses for the new state (empty) *)
+        log_info ~notify_back
+        @@ spr "notify_back#uri: %s"
+             (notify_back#get_uri |> O.map_or Uri.to_string ~default:"");
         let diags = O.map_or ~default:[] diagnose new_state in
         notify_back#send_diagnostic (diags @ new_diags)
       in
       (* consider matching on TextDocumentItem.languageId *)
       match Filename.extension filename with
       | ".mll" -> go mll_buffers Mll.load_state_from_contents Mll.diagnostics
-      | ".mly" -> go mly_buffers Mly.load_state_from_contents (fun _ -> [])
+      | ".mly" ->
+          go mly_buffers Mly.load_state_from_contents
+            (Mly.diagnostics ~notify_back ~uri)
       | ext ->
           notify_back#send_log_msg ~type_:Error
           @@ spr "Unhandled document type: %s" ext
@@ -276,8 +280,9 @@ class lsp_server =
     (* We now override the [on_notify_doc_did_open] method that will be called
             by the server each time a new document is opened. *)
     method on_notif_doc_did_open ~notify_back d ~content : unit Linol_lwt.t =
+      get_build_dir () |> ignore;
       find_merlin_config ~notify_back ~uri:d.uri |> ignore;
-      notify_back#send_log_msg ~type_:Info (spr "Language id: %s" d.languageId);%lwt
+      log_info ~notify_back (spr "Language id: %s" d.languageId);
       self#_on_doc ~notify_back d.uri content
 
     (* Similarly, we also override the [on_notify_doc_did_change] method that will be called

--- a/bin/menhir.ml
+++ b/bin/menhir.ml
@@ -17,8 +17,8 @@ type state = {
   symbols : string located list;
 }
 
-let get_cmly_file ~uri = fetch_build_dir ~ext:".cmly" uri
-let get_conflicts_file ~uri = fetch_build_dir ~ext:".conflicts" uri
+let get_cmly_file = fetch_build_dir ~ext:".cmly"
+let get_conflicts_file = fetch_build_dir ~ext:".conflicts"
 
 let rec string_of_params : parameter -> string = function
   | M.Syntax.ParamVar p -> p.v
@@ -244,63 +244,62 @@ let hover (state : state) ~(pos : Position.t) : Hover.t option =
     ~range ()
 
 let diagnostics ~(notify_back : notify_back) ~(uri : uri) (_s : state) :
-    Lsp.Types.Diagnostic.t list =
+    Diagnostic.t list =
   let log = log_info ~notify_back in
-  try
-    let open R in
-    let conflicts_file = get_conflicts_file ~uri |> get_exn in
-    log "conflicts_file: %s" conflicts_file;
-    let module P = CCParse in
-    let module S = CCString in
-    let mk_diag (toks : token located list) lines =
-      let message = S.concat "\n" @@ lines in
-      Diagnostic.create ~range:Range.first_line ~source:conflicts_file
-        ~relatedInformation:
-          L.(
-            let+ tk = toks in
-            (* log
+  let open R in
+  get_or_nil
+  @@
+  let* conflicts_file = get_conflicts_file uri in
+  log "conflicts_file: %s" conflicts_file;
+  let module P = CCParse in
+  let module S = CCString in
+  let mk_diag (toks : token located list) lines =
+    let message = S.concat "\n" @@ lines in
+    Diagnostic.create ~range:Range.first_line ~source:conflicts_file
+      ~relatedInformation:
+        L.(
+          let+ tk = toks in
+          (* log
              "token name: %s %s" tk.v.terminal
                  Range.(of_lexical_positions tk.p |> show); *)
-            DiagnosticRelatedInformation.create
-              ~location:
-                (Location.create ~uri ~range:(Range.of_lexical_positions tk.p))
-              ~message:(spr "%s is involved." tk.v.terminal))
-        ~message:
-          (* Contrary to the OCaml type, the protocol doesn't support Markdown in the diagnostic message. (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic), and in fact the vscode extension crashes. Quite the pickle, because the bits of the conflict message showing derivations trees require a monospace font for best viewing.
+          DiagnosticRelatedInformation.create
+            ~location:
+              (Location.create ~uri ~range:(Range.of_lexical_positions tk.p))
+            ~message:(spr "%s is involved." tk.v.terminal))
+      ~message:
+        (* Contrary to the OCaml type, the protocol doesn't support Markdown in the diagnostic message. (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic), and in fact the vscode extension crashes. Quite the pickle, because the bits of the conflict message showing derivations trees require a monospace font for best viewing.
 
             (`MarkupContent (MarkupContent.create ~kind:Markdown ~value:message))
 
           *)
-          (`String message) ()
-    in
-    let tokens_prefix = "** Tokens involved:" in
-    In_channel.with_open_text conflicts_file (fun inp ->
-        In_channel.input_all inp |> S.trim |> S.split ~by:"\n"
-        (* |> S.replace ~sub:"\n\n" ~by:"\n```\n" *)
-        (* markdown not supported *)
-        |> fun lines ->
-        List.fold_right
-          (fun line acc ->
-            let chop s =
-              s |> S.chop_prefix ~pre:"** " |> O.get_or ~default:line
-            in
-            match acc with
-            | toks, current_diag, diags
-              when String.starts_with ~prefix:"** Conflict" line ->
-                ([], [], mk_diag toks (chop line :: current_diag) :: diags)
-            | _, current_diag, diags
-              when String.starts_with ~prefix:tokens_prefix line ->
-                ( S.chop_prefix ~pre:tokens_prefix line
-                  |> Option.get |> S.trim |> S.split ~by:" "
-                  |> L.map (fun tk ->
-                      L.find (fun { v; _ } -> S.equal v.terminal tk) _s.tokens),
-                  chop line :: current_diag,
-                  diags )
-            | toks, current_diag, diags ->
-                (toks, chop line :: current_diag, diags))
-          lines ([], [], [])
-        |> fun (_, _, diags) -> diags)
-  with _ -> []
+        (`String message) ()
+  in
+  let tokens_prefix = "** Tokens involved:" in
+  In_channel.with_open_text conflicts_file (fun inp ->
+      In_channel.input_all inp |> S.trim |> S.split ~by:"\n"
+      (* |> S.replace ~sub:"\n\n" ~by:"\n```\n" *)
+      (* markdown not supported *)
+      |> fun lines ->
+      List.fold_right
+        (fun line acc ->
+          let chop s =
+            s |> S.chop_prefix ~pre:"** " |> O.get_or ~default:line
+          in
+          match acc with
+          | toks, current_diag, diags
+            when String.starts_with ~prefix:"** Conflict" line ->
+              ([], [], mk_diag toks (chop line :: current_diag) :: diags)
+          | _, current_diag, diags
+            when String.starts_with ~prefix:tokens_prefix line ->
+              ( S.chop_prefix ~pre:tokens_prefix line
+                |> Option.get |> S.trim |> S.split ~by:" "
+                |> L.map (fun tk ->
+                    L.find (fun { v; _ } -> S.equal v.terminal tk) _s.tokens),
+                chop line :: current_diag,
+                diags )
+          | toks, current_diag, diags -> (toks, chop line :: current_diag, diags))
+        lines ([], [], [])
+      |> fun (_, _, diags) -> Ok diags)
 
 let references (state : state) ~uri ~(pos : Position.t) : Location.t list =
   (let open O in

--- a/bin/menhir.ml
+++ b/bin/menhir.ml
@@ -249,7 +249,7 @@ let diagnostics ~(notify_back : notify_back) ~(uri : uri) (_s : state) :
   try
     let open R in
     let conflicts_file = get_conflicts_file ~uri |> get_exn in
-    log @@ spr "conflicts_file: %s" conflicts_file;
+    log "conflicts_file: %s" conflicts_file;
     let module P = CCParse in
     let module S = CCString in
     let mk_diag (toks : token located list) lines =
@@ -259,7 +259,7 @@ let diagnostics ~(notify_back : notify_back) ~(uri : uri) (_s : state) :
           L.(
             let+ tk = toks in
             (* log
-            @@ spr "token name: %s %s" tk.v.terminal
+             "token name: %s %s" tk.v.terminal
                  Range.(of_lexical_positions tk.p |> show); *)
             DiagnosticRelatedInformation.create
               ~location:

--- a/bin/menhir.ml
+++ b/bin/menhir.ml
@@ -354,6 +354,7 @@ let completions ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
   let pos_inside = Position.is_inside pos in
   let merlin_compls () =
     (let* word = word in
+     log_info ~notify_back "hello?";
      get_merlin_compls ~notify_back ~uri ~pos word)
     |> get_or ~default:[]
   in
@@ -366,7 +367,7 @@ let completions ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
         | DToken (Some (Declared { p; _ }), _, _, _)
         | DParameter { p; _ } ->
             let range = Range.of_lexical_positions p in
-            if_ (fun _ -> pos_inside range) (merlin_compls ())
+            if pos_inside range then Some (merlin_compls ()) else None
         | _ -> None)
       grammar.pg_declarations
   in
@@ -390,9 +391,8 @@ let completions ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
               | M.IL.ETextual { p; _ } -> Some (Range.of_lexical_positions p)
               | _ -> None
             in
-            if_
-              (fun _ -> pos_inside action_range)
-              (Keywords.position_keywords ?range:word_range ()
+            if pos_inside action_range then
+              Keywords.position_keywords ?range:word_range ()
               @ (let open L in
                  let+ binder, par, _ = branch.pb_producers in
                  let binder =
@@ -407,7 +407,9 @@ let completions ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
                        let+ range = word_range in
                        `TextEdit TextEdit.{ newText = binder; range })
                    ())
-              @ merlin_compls ()))
+              @ merlin_compls ()
+              |> some
+            else None)
           rule.pr_branches)
       grammar.pg_rules
   in

--- a/bin/ocamllex.ml
+++ b/bin/ocamllex.ml
@@ -266,7 +266,8 @@ let completions ({ grammar = { header; trailer; _ } as grammar; _ } : state)
     |> get_or ~default:[]
   in
   let header_completions () =
-    if_ (fun _ -> pos_inside header || pos_inside trailer) (merlin_compls ())
+    if pos_inside header || pos_inside trailer then Some (merlin_compls ())
+    else None
   in
   (* Inside actions we shall suggest `lexbuf`, the variables bound with `as` in the current clause, the lexer entrypoints, and OCaml symbols *)
   let action_completions () =
@@ -275,11 +276,10 @@ let completions ({ grammar = { header; trailer; _ } as grammar; _ } : state)
         L.find_map
           (fun (regexp, r) ->
             let range = Range.of_lexical_positions r in
-            if_
-              (fun _ -> pos_inside range)
-              (L.(
-                 let+ arg = rule.args in
-                 CompletionItem.create ~kind:Value ~label:arg.v ())
+            if pos_inside range then
+              L.(
+                let+ arg = rule.args in
+                CompletionItem.create ~kind:Value ~label:arg.v ())
               @ L.(
                   let+ entry = grammar.entrypoints in
                   CompletionItem.create ~kind:Function ~label:entry.name.v ())
@@ -300,7 +300,9 @@ let completions ({ grammar = { header; trailer; _ } as grammar; _ } : state)
                         manual_ref "ss:ocamllex-actions";
                       ] );
                   ]
-              @ merlin_compls ()))
+              @ merlin_compls ()
+              |> some
+            else None)
           rule.clauses)
       grammar.entrypoints
   in

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -186,30 +186,29 @@ let compile_completions ?(range : Range.t option) ~(kind : CompletionItemKind.t)
                       ~value:(String.concat "\n\n" docs))))
         ())
 
-let build_dirs : (uri, string * string) Hashtbl.t = Hashtbl.create 42
+let _build_dir  = ref (Error "")
 
-let get_build_dirs uri =
-  let open R in
-  let f _ =
-    let s =
+let get_build_dir _ =
+  let f () =
+    let err = Error "Failure: dune describe" in
+    try
       let inp = Unix.open_process_in "dune describe workspace" in
       let s = CCSexp.parse_chan inp in
       In_channel.close inp;
-      s
-    in
-    match s with
-    | Ok
-        (`List
-           (`List [ `Atom "root"; `Atom root_dir ]
-           :: `List [ `Atom "build_context"; `Atom context ]
-           :: _)) ->
-        (root_dir, context)
-    | _ -> failwith "bad pattern"
+      match s with
+      | Ok
+          (`List
+             (`List [ `Atom "root"; `Atom root_dir ]
+             :: `List [ `Atom "build_context"; `Atom context ]
+             :: _)) ->
+          _build_dir := Ok (root_dir, context);
+          !_build_dir
+      | _ -> err
+    with _ ->
+      (* May fail due to 'A running dune (pid: ..) instance has locked the build directory.') *)
+      err
   in
-  try CCHashtbl.get_or_add build_dirs ~k:uri ~f |> R.return
-  with _ ->
-    (* May fail due to 'A running dune (pid: ..) instance has locked the build directory.') *)
-    Error "Failed to read dune describe's output"
+  match !_build_dir with Ok _ -> !_build_dir | Error _ -> f ()
 
 (** e.g. if [uri] is
 
@@ -226,7 +225,7 @@ let fetch_build_dir ?(ext : string option) uri =
   let s_slug = F.remove_extension s_name in
   let s_ext = O.get_or ~default:(F.extension s_name) ext in
   let open R in
-  let* root, ctx = get_build_dirs uri in
+  let* root, ctx = get_build_dir () in
   let p_root = P.of_string root in
   let p_dir = P.of_string (F.dirname s_path) in
   match P.drop_prefix p_dir ~prefix:p_root with

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -39,8 +39,11 @@ let pr = Pr.printf
 let spr = Pr.sprintf
 let epr = Pr.eprintf
 
-let log_info ~(notify_back : notify_back) s =
-  s |> notify_back#send_log_msg ~type_:Info |> ignore
+let log ~(notify_back : notify_back) ~type_ =
+  Printf.ksprintf (fun s -> notify_back#send_log_msg ~type_ s |> ignore)
+
+let log_info ~(notify_back : notify_back) = log ~notify_back ~type_:Info
+let log_error ~(notify_back : notify_back) = log ~notify_back ~type_:Error
 
 (** Adapted from
     https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/position.ml
@@ -262,12 +265,11 @@ let get_merlin_config ~(notify_back : notify_back) ~(uri : uri) =
   let dot, failures = MK.Mconfig_dot.get_config ctx path in
   let concat = String.concat ", " in
   log_info ~notify_back
-  @@ spr
-       {|Search result for Merlin config of %s:
+    {|Search result for Merlin config of %s:
   Errors: %s
   Source path: %s
   Build path: %s|}
-       path (concat failures) (concat dot.source_path) (concat dot.build_path);
+    path (concat failures) (concat dot.source_path) (concat dot.build_path);
   let merlin =
     MK.Mconfig.merge_merlin_config dot MK.Mconfig.initial.merlin ~failures
       ~config_path
@@ -279,8 +281,8 @@ let find_merlin_config ~notify_back ~uri =
   match Hashtbl.find_opt merlin_configs uri with
   | None ->
       log_info ~notify_back
-      @@ spr "couldn't find merlin config for %s, generating new one"
-           (DocumentUri.to_path uri);
+        "couldn't find merlin config for %s, generating new one"
+        (DocumentUri.to_path uri);
       let+ config = get_merlin_config ~notify_back ~uri in
       Hashtbl.add merlin_configs uri config;
       config
@@ -333,5 +335,5 @@ let get_merlin_compls ~(notify_back : notify_back) ~(uri : uri)
               ())
           compls.entries
       in
-      log_info ~notify_back @@ spr "# merlin completions: %d" (L.length compls);
+      log_info ~notify_back "# merlin completions: %d" (L.length compls);
       compls)

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -9,9 +9,16 @@ module O = struct
 
   let ( <|> ) (a : 'a option) (b : unit -> 'a option) =
     match (a, b) with Some a, _ -> Some a | None, f -> f ()
+
+  let get_or_nil (t : 'a list t) : 'a list = get_or ~default:[] t
 end
 
-module R = CCResult
+module R = struct
+  include CCResult
+
+  let get_or_nil (t : ('a list, 'err) t) : 'a list = get_or ~default:[] t
+end
+
 module A = CCArray
 module F = CCFun
 module C = CCChar
@@ -21,6 +28,7 @@ module Lsp = Linol_lsp.Lsp
 module Loc = M.Located
 module Log = (val Logs.src_log Linol.logs_src)
 include Lsp.Types
+module Uri = DocumentUri
 module Text_document = Lsp.Text_document
 
 type notify_back = Linol_lwt.Jsonrpc2.notify_back
@@ -186,7 +194,7 @@ let compile_completions ?(range : Range.t option) ~(kind : CompletionItemKind.t)
                       ~value:(String.concat "\n\n" docs))))
         ())
 
-let _build_dir  = ref (Error "")
+let _build_dir = ref (Error "")
 
 let get_build_dir _ =
   let f () =

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -35,6 +35,11 @@ export function activate(context: vscode.ExtensionContext) {
       { scheme: "file", language: "ocaml.menhir" },
       { scheme: "file", language: "ocaml.ocamllex" },
     ],
+    synchronize: {
+      fileEvents: vscode.workspace.createFileSystemWatcher(
+        "**/*.conflicts"
+      ),
+    },
   };
 
   client = new LanguageClient(


### PR DESCRIPTION
The server can extract diagnostics from the .conflicts file of the currently opened document, generated automatically whenever the project is built with dune. The conflict diagnostics are updated automatically when the project is rebuilt.

The range used for the diagnostics could be improved, for now it is the first line of the document.

Closes #1