### PR TITLE
Fix document formatting bugs and interface

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -19,4 +19,5 @@
   re
   stdune
   interval-map
-  menhir_lsp_lib))
+  menhir_lsp_lib)
+ (flags -w -27))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2,6 +2,7 @@ open Utils
 open Menhir_lsp_lib
 module Mll = Ocamllex
 module Mly = Menhir
+module MF = Menhirformat_lib
 
 (* Based on Linol's Lwt template: https://github.com/c-cube/linol/blob/main/example/template-lwt/main.ml *)
 class lsp_server =
@@ -179,7 +180,7 @@ class lsp_server =
             self#_on_req_document_formatting ~notify_back ~r
         | _ -> Lwt.fail_with "Unhandled request type"
 
-    (* Wasted a lot of time thinking this request was not handled natively by Linol*)
+    (* Wasted a lot of time thinking this request was not handled natively by Linol *)
     method! on_req_execute_command ~notify_back ~id:_ ~workDoneToken:_
         (command : string) (args : Yojson.Safe.t list option) : Json.t Lwt.t =
       Lwt.return
@@ -210,8 +211,34 @@ class lsp_server =
       @@
       let open O in
       let* doc = self#get_text_document ~uri in
-      self#_dispatch uri ~notify_back ~mll_handler:(Mll.format ~doc ~options)
-        ~mly_handler:(Mly.format ~doc ~options)
+      let config = MF.Utils.Config.{ tabsize = options.tabSize } in
+      let filename = doc |> Text_document.documentUri |> Uri.to_path in
+      let format _ ~parse ~format =
+        match parse (Text_document.text doc) with
+        | Ok ast ->
+            let newText = format ~config ~ast ~doc in
+            [ TextEdit.create ~newText ~range:Range.(whole_document doc) ]
+        | Error (msg, range) ->
+            let message =
+              spr "menhirformat: ignoring \"%s\" (syntax error) %s %s" filename
+                (OcamllexSyntax.Range.show range)
+                msg
+            in
+            notify_back#send_log_msg ~type_:Warning message |> ignore;
+            notify_back#send_notification
+              (ShowMessage { message; type_ = Warning })
+            |> ignore;
+            (* todo: maybe returning None in this case is more semantically correct. Check the spec. *)
+            []
+      in
+      self#_dispatch uri ~notify_back
+        ~mll_handler:
+          (format ~parse:OcamllexSyntax.Main.parse_string
+             ~format:MF.Ocamllex.main)
+        ~mly_handler:
+          (format
+             ~parse:(MenhirSyntax.Main.load_grammar_from_contents 0 filename)
+             ~format:MF.Menhir.main)
 
     method private _on_req_references =
       fun ~notify_back ~id:_ ~uri ~pos : Location.t list option Lwt.t ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4,6 +4,8 @@ module Mll = Ocamllex
 module Mly = Menhir
 module MF = Menhirformat_lib
 
+let formatter_config : MF.Utils.Config.t option ref = ref None
+
 (* Based on Linol's Lwt template: https://github.com/c-cube/linol/blob/main/example/template-lwt/main.ml *)
 class lsp_server =
   object (self)
@@ -116,8 +118,29 @@ class lsp_server =
 
     method! on_notification_unhandled ~notify_back =
       function
-      (* The code below is needed to sync the diagnostics with the current grammar's conflicts. *)
+      | ChangeConfiguration { settings } ->
+          (* This case keeps the menhirformat config of the server in sync with the client's.
+
+          Note: according to the LSP spec, this "push" model of configuration synchronization,
+          where the client notifies the server every time some setting is changed, is deprecated.
+
+          The server should instead pull the relevant section of the client's config through
+          a server request (e.g. inside the [documentFormatting] request handler).
+          See example in [on_notif_doc_did_open].
+          *)
+          Json.Util.(settings |> member "menhir" |> member "format")
+          |> MF.Utils.Config.of_yojson
+          |> ( function
+          | Ok cfg ->
+              formatter_config := Some cfg;
+              log_info ~notify_back "Updated formatter's settings: %s"
+                (Json.to_string settings)
+          | Error s ->
+              log_error ~notify_back
+                "Error while updating formatter's settings %s" s )
+          |> Lwt.return
       | DidChangeWatchedFiles params ->
+          (* This case syncs the diagnostics with the currently opened grammar's conflicts. *)
           let open R in
           let module P = Stdune.Path in
           let module F = Filename in
@@ -211,7 +234,11 @@ class lsp_server =
       @@
       let open O in
       let* doc = self#get_text_document ~uri in
-      let config = MF.Utils.Config.{ default_config with tabsize = options.tabSize } in
+      let config =
+        let open MF.Utils.Config in
+        let cfg = O.get_or ~default:default_config !formatter_config in
+        { cfg with tabsize = options.tabSize }
+      in
       let filename = doc |> Text_document.documentUri |> Uri.to_path in
       let format _ ~parse ~format =
         match parse (Text_document.text doc) with
@@ -339,6 +366,26 @@ class lsp_server =
       get_build_dir () |> ignore;
       find_merlin_config ~notify_back ~uri:d.uri |> ignore;
       log_info ~notify_back "Language id: %s" d.languageId;
+      let%lwt _ =
+        let error _ =
+          log_error ~notify_back "Error retrieving formatter settings";
+          Lwt.return ()
+        in
+        notify_back#send_request
+          (WorkspaceConfiguration
+             (ConfigurationParams.create
+                ~items:[ ConfigurationItem.create ~section:"menhir.format" () ]))
+          (function
+            | Ok (j :: _) -> (
+                log_info ~notify_back "Found formatter settings: %s "
+                  (Json.to_string j);
+                match Menhirformat_lib.Utils.Config.of_yojson j with
+                | Ok cfg ->
+                    formatter_config := Some cfg;
+                    Lwt.return ()
+                | Error _ -> error ())
+            | _ -> error ())
+      in
       self#_on_doc ~notify_back d.uri content
 
     (* Similarly, we also override the [on_notify_doc_did_change] method that will be called

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -211,7 +211,7 @@ class lsp_server =
       @@
       let open O in
       let* doc = self#get_text_document ~uri in
-      let config = MF.Utils.Config.{ tabsize = options.tabSize } in
+      let config = MF.Utils.Config.{ default_config with tabsize = options.tabSize } in
       let filename = doc |> Text_document.documentUri |> Uri.to_path in
       let format _ ~parse ~format =
         match parse (Text_document.text doc) with

--- a/bin/menhir.ml
+++ b/bin/menhir.ml
@@ -825,9 +825,3 @@ let selection_range ({ grammar; _ } as _state : state)
       (Range.show res.SelectionRange.range);
     res)
   |> O.to_list
-
-let format (state : state) ~(doc : Text_document.t)
-    ~(options : FormattingOptions.t) : TextEdit.t list =
-  let config = Menhirformat_lib.Utils.Config.{ tabsize = options.tabSize } in
-  let newText = Menhirformat_lib.Menhir.main ~config ~doc ~ast:state.grammar in
-  [ TextEdit.create ~newText ~range:Range.(whole_document doc) ]

--- a/bin/menhir.ml
+++ b/bin/menhir.ml
@@ -279,8 +279,8 @@ let load_state_from_partial_grammar (grammar : partial_grammar) =
       method! visit_Declared _ = ocaml_zone
       method! visit_DParameter _ = ocaml_zone
 
-      method! visit_action _ =
-        function ETextual loc -> action_zone loc | _ -> ()
+      method! visit_action _ { expr; _ } =
+        match expr with ETextual loc -> action_zone loc | _ -> ()
 
       method! visit_partial_grammar =
         fun _ ({ pg_declarations; pg_rules; pg_postlude; _ } as grammar) ->

--- a/bin/menhir.ml
+++ b/bin/menhir.ml
@@ -827,6 +827,7 @@ let selection_range ({ grammar; _ } as _state : state)
   |> O.to_list
 
 let format (state : state) ~(doc : Text_document.t)
-    ~options:(_ : FormattingOptions.t) : TextEdit.t list =
-  let newText = Menhirformat_lib.Menhir.main ~doc ~ast:state.grammar in
+    ~(options : FormattingOptions.t) : TextEdit.t list =
+  let config = Menhirformat_lib.Utils.Config.{ tabsize = options.tabSize } in
+  let newText = Menhirformat_lib.Menhir.main ~config ~doc ~ast:state.grammar in
   [ TextEdit.create ~newText ~range:Range.(whole_document doc) ]

--- a/bin/ocamllex.ml
+++ b/bin/ocamllex.ml
@@ -462,6 +462,9 @@ let code_actions ({ regexps; grammar; _ } : state) ~(notify_back : notify_back)
   Some [ `CodeAction extract_action ]
 
 let format (state : state) ~(doc : Text_document.t)
-    ~options:(_ : FormattingOptions.t) : TextEdit.t list =
-  let newText = Menhirformat_lib.Ocamllex.main ~doc ~ast:state.grammar in
+    ~(options : FormattingOptions.t) : TextEdit.t list =
+  let config = Menhirformat_lib.Utils.Config.{ tabsize = options.tabSize } in
+  let newText =
+    Menhirformat_lib.Ocamllex.main ~config ~doc ~ast:state.grammar
+  in
   [ TextEdit.create ~newText ~range:Range.(whole_document doc) ]

--- a/bin/ocamllex.ml
+++ b/bin/ocamllex.ml
@@ -460,11 +460,3 @@ let code_actions ({ regexps; grammar; _ } : state) ~(notify_back : notify_back)
       ()
   in
   Some [ `CodeAction extract_action ]
-
-let format (state : state) ~(doc : Text_document.t)
-    ~(options : FormattingOptions.t) : TextEdit.t list =
-  let config = Menhirformat_lib.Utils.Config.{ tabsize = options.tabSize } in
-  let newText =
-    Menhirformat_lib.Ocamllex.main ~config ~doc ~ast:state.grammar
-  in
-  [ TextEdit.create ~newText ~range:Range.(whole_document doc) ]

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -71,7 +71,33 @@
 				"enablement": "never",
 				"command": "menhir-lsp-client.promptAlias"
 			}
-		]
+		],
+		"configuration": {
+			"type": "object",
+			"title": "Menhir LSP - Formatting options",
+			"properties": {
+				"menhir.format.maxWidth": {
+					"type": "integer",
+					"default": 80,
+					"description": "Maximum number of characters per line."
+				},
+				"menhir.format.indentOnce": {
+					"type": "boolean",
+					"default": false,
+					"description": "Add a level of indentation to the cases of a rule or (default) keep them flush with the start of the definition."
+				},
+				"menhir.format.noLeadingBar": {
+					"type": "boolean",
+					"default": false,
+					"description": "Omit the optional leading bar `|` in the first case of a rule."
+				},
+				"menhir.format.semiAfterProducer": {
+					"type": "boolean",
+					"default": false,
+					"description": "Terminate every producer with a semicolon in Menhir rules written in the traditional syntax."
+				}
+			}
+		}
 	},
 	"main": "./out/extension.js",
 	"scripts": {

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -38,6 +38,7 @@ export function activate(context: vscode.ExtensionContext) {
       { scheme: "file", language: "ocaml.ocamllex" },
     ],
     synchronize: {
+      configurationSection: ["menhir.format"],
       fileEvents: vscode.workspace.createFileSystemWatcher("**/*.conflicts"),
     },
   };

--- a/prettyprint/dune
+++ b/prettyprint/dune
@@ -4,20 +4,18 @@
  (package menhirformat)
  (libraries
   ANSITerminal
+  cmdliner
   menhirSyntax
   ocamllexSyntax
   ocamlformat-rpc-lib
   menhir_lsp_lib
   menhirformat_lib)
- (modules main))
+ (modules main)
+ (flags -w +27))
 
 (library
  (name menhirformat_lib)
- (libraries
-  menhirSyntax
-  ocamllexSyntax
-  ocamlformat-rpc-lib
-  menhir_lsp_lib)
+ (libraries menhirSyntax ocamllexSyntax ocamlformat-rpc-lib menhir_lsp_lib)
  (modules utils comment_location comments ocamlformat_client ocamllex menhir))
 
 (ocamllex comments)

--- a/prettyprint/dune
+++ b/prettyprint/dune
@@ -15,6 +15,8 @@
 
 (library
  (name menhirformat_lib)
+ (preprocess
+  (pps ppx_deriving.make))
  (libraries menhirSyntax ocamllexSyntax ocamlformat-rpc-lib menhir_lsp_lib)
  (modules utils comment_location comments ocamlformat_client ocamllex menhir))
 

--- a/prettyprint/dune
+++ b/prettyprint/dune
@@ -16,8 +16,13 @@
 (library
  (name menhirformat_lib)
  (preprocess
-  (pps ppx_deriving.make))
- (libraries menhirSyntax ocamllexSyntax ocamlformat-rpc-lib menhir_lsp_lib)
+  (pps ppx_deriving.make ppx_deriving_yojson))
+ (libraries
+  menhirSyntax
+  ocamllexSyntax
+  ocamlformat-rpc-lib
+  menhir_lsp_lib
+  ppx_deriving_yojson.runtime)
  (modules utils comment_location comments ocamlformat_client ocamllex menhir))
 
 (ocamllex comments)

--- a/prettyprint/main.ml
+++ b/prettyprint/main.ml
@@ -1,13 +1,8 @@
 open Menhir_lsp_lib.Utils
+open Menhirformat_lib.Utils
 
 let version = "0.0.0"
-let input_file = ref ""
-
-let log s = Format.ksprintf (prerr_endline) s
-
-let print_version () =
-  log "%s" version;
-  exit 0
+let log s = Format.ksprintf prerr_endline s
 
 let read_file_contents filename =
   try
@@ -19,34 +14,48 @@ let read_file_contents filename =
     log "File doesn't exist: %s" filename;
     exit 1
 
-let () =
-  Arg.parse
-    [ ("-v", Unit print_version, "Print the version of menhirformat") ]
-    (fun anon -> input_file := anon)
-    {|A formatter for Ocamllex and Menhir specifications.
+open Cmdliner
+open Cmdliner.Term.Syntax
 
-Usage: menhirformat [INPUT_FILE]|};
+let tabsize =
+  let doc = "Whitespace unit for indentation" in
+  Arg.(value & opt int 2 & info [ "t"; "tabsize" ] ~docv:"COLS" ~doc)
 
-  let text = read_file_contents !input_file in
+let input_file =
+  let doc = "The file to format, whose name must end with the `.mly' or `.mll' file extension." in
+  Arg.(value & pos 0 file "" & info [] ~docv:"FILE" ~doc)
+
+let main ~tabsize (input_file : string) =
+  let open R in
+  let text = read_file_contents input_file in
   let doc =
     TD.make ~position_encoding:`UTF8
       {
         textDocument =
-          { languageId = ""; text; uri = Uri.of_path !input_file; version = 0 };
+          { languageId = ""; text; uri = Uri.of_path input_file; version = 0 };
       }
   in
-
-  let open R in
-  match Filename.extension !input_file with
+  let config = Config.make ~tabsize in
+  match Filename.extension input_file with
   | ".mly" -> (
-      match MenhirSyntax.Main.load_grammar_from_file !input_file with
-      | Ok ast -> Menhirformat_lib.Menhir.main ~doc ~ast |> print_endline
+      match MenhirSyntax.Main.load_grammar_from_file input_file with
+      | Ok ast ->
+          Menhirformat_lib.Menhir.main ~config ~doc ~ast |> print_endline
       | Error _ -> ())
   | ".mll" -> (
       match OcamllexSyntax.Main.parse_string text with
-      | Ok ast -> Menhirformat_lib.Ocamllex.main ~doc ~ast |> print_endline
+      | Ok ast ->
+          Menhirformat_lib.Ocamllex.main ~config ~doc ~ast |> print_endline
       | Error _ -> ())
   | _ ->
-      log "%s"
-        "Unrecognized file extension: must be '.mll' or '.mly'.";
+      log "%s" "Unrecognized file extension: must be either '.mll' or '.mly'.";
       exit 2
+
+let cmd =
+  Cmd.v
+    (Cmd.info "menhirformat" ~version
+       ~doc:"A formatter for Ocamllex and Menhir specifications.")
+  @@ let+ input_file = input_file and+ tabsize = tabsize in
+     main ~tabsize input_file
+
+let () = if !Sys.interactive then () else exit (Cmd.eval cmd)

--- a/prettyprint/main.ml
+++ b/prettyprint/main.ml
@@ -34,10 +34,25 @@ let indentOnce =
 
 let semiAfterProducer =
   let doc =
-    "Add a semicolon after every semicolon in traditional syntax Menhir rules (it is required \
-     in the new syntax)."
+    "Add a semicolon after every semicolon in traditional syntax Menhir rules \
+     (it is required in the new syntax)."
   in
   Arg.(value & flag & info [ "semi-after-producer" ] ~doc)
+
+let breakLongRegexps =
+  let doc =
+    "Break long ocamllex regexps onto multiple lines when they don't fit in a \
+     single line. Breaking may happen only at concatenations or alternations \
+     outside groups."
+  in
+  Arg.(value & flag & info [ "break-long-regexps" ] ~doc)
+
+let breakRegexpsGroups =
+  let doc =
+    "Allow breaking to happen inside regexp groups. Effective only when \
+     $(b,--break-long-regexps) is set."
+  in
+  Arg.(value & flag & info [ "break-regexp-groups" ] ~doc)
 
 let input_file =
   let doc =
@@ -68,7 +83,7 @@ let main ~config (input_file : string) =
 let cmd =
   Cmd.v
     (Cmd.info "menhirformat" ~version
-       ~doc:"A formatter for Ocamllex and Menhir specifications.")
+       ~doc:"A formatter for Ocamllex .mll and Menhir .mly files.")
   @@ let+ input_file = input_file
      and+ tabsize = tabsize
      and+ indentOnce = indentOnce

--- a/prettyprint/main.ml
+++ b/prettyprint/main.ml
@@ -18,19 +18,26 @@ open Cmdliner
 open Cmdliner.Term.Syntax
 
 let tabsize =
-  let doc = "Whitespace unit for indentation" in
+  let doc = "Whitespace unit for indentation." in
   Arg.(value & opt int 2 & info [ "t"; "tabsize" ] ~docv:"COLS" ~doc)
 
 let noLeadingBar =
   let doc = "Omit the optional leading bar `|` in the first case of a rule." in
-  Arg.(value & flag & info [ "noLeadingBar" ] ~doc)
+  Arg.(value & flag & info [ "no-leading-bar" ] ~doc)
 
 let indentOnce =
   let doc =
     "Add a level of indentation to the cases of a rule or (default) keep them \
      flush with the start of the definition."
   in
-  Arg.(value & flag & info [ "indentOnce" ] ~doc)
+  Arg.(value & flag & info [ "indent-rule" ] ~doc)
+
+let semiAfterProducer =
+  let doc =
+    "Add a semicolon after every semicolon in traditional syntax Menhir rules (it is required \
+     in the new syntax)."
+  in
+  Arg.(value & flag & info [ "semi-after-producer" ] ~doc)
 
 let input_file =
   let doc =
@@ -65,8 +72,11 @@ let cmd =
   @@ let+ input_file = input_file
      and+ tabsize = tabsize
      and+ indentOnce = indentOnce
-     and+ noLeadingBar = noLeadingBar in
-     let config = Config.make ~tabsize ~indentOnce ~noLeadingBar in
+     and+ noLeadingBar = noLeadingBar
+     and+ semiAfterProducer = semiAfterProducer in
+     let config =
+       Config.make ~tabsize ~indentOnce ~noLeadingBar ~semiAfterProducer ()
+     in
      main ~config input_file
 
 let () = if !Sys.interactive then () else exit (Cmd.eval cmd)

--- a/prettyprint/main.ml
+++ b/prettyprint/main.ml
@@ -21,21 +21,28 @@ let tabsize =
   let doc = "Whitespace unit for indentation" in
   Arg.(value & opt int 2 & info [ "t"; "tabsize" ] ~docv:"COLS" ~doc)
 
+let noLeadingBar =
+  let doc = "Omit the optional leading bar `|` in the first case of a rule." in
+  Arg.(value & flag & info [ "noLeadingBar" ] ~doc)
+
+let indentOnce =
+  let doc =
+    "Add a level of indentation to the cases of a rule or (default) keep them \
+     flush with the start of the definition."
+  in
+  Arg.(value & flag & info [ "indentOnce" ] ~doc)
+
 let input_file =
-  let doc = "The file to format, whose name must end with the `.mly' or `.mll' file extension." in
+  let doc =
+    "The file to format, whose name must end with the `.mly' or `.mll' file \
+     extension."
+  in
   Arg.(value & pos 0 file "" & info [] ~docv:"FILE" ~doc)
 
-let main ~tabsize (input_file : string) =
+let main ~config (input_file : string) =
   let open R in
   let text = read_file_contents input_file in
-  let doc =
-    TD.make ~position_encoding:`UTF8
-      {
-        textDocument =
-          { languageId = ""; text; uri = Uri.of_path input_file; version = 0 };
-      }
-  in
-  let config = Config.make ~tabsize in
+  let doc = doc_of_string ~input_file text in
   match Filename.extension input_file with
   | ".mly" -> (
       match MenhirSyntax.Main.load_grammar_from_file input_file with
@@ -55,7 +62,11 @@ let cmd =
   Cmd.v
     (Cmd.info "menhirformat" ~version
        ~doc:"A formatter for Ocamllex and Menhir specifications.")
-  @@ let+ input_file = input_file and+ tabsize = tabsize in
-     main ~tabsize input_file
+  @@ let+ input_file = input_file
+     and+ tabsize = tabsize
+     and+ indentOnce = indentOnce
+     and+ noLeadingBar = noLeadingBar in
+     let config = Config.make ~tabsize ~indentOnce ~noLeadingBar in
+     main ~config input_file
 
 let () = if !Sys.interactive then () else exit (Cmd.eval cmd)

--- a/prettyprint/main.ml
+++ b/prettyprint/main.ml
@@ -21,6 +21,10 @@ let tabsize =
   let doc = "Whitespace unit for indentation." in
   Arg.(value & opt int 2 & info [ "t"; "tabsize" ] ~docv:"COLS" ~doc)
 
+let maxColumns =
+  let doc = "Maximum number of characters per line." in
+  Arg.(value & opt int 80 & info [ "w"; "width" ] ~docv:"COLS" ~doc)
+
 let noLeadingBar =
   let doc = "Omit the optional leading bar `|` in the first case of a rule." in
   Arg.(value & flag & info [ "no-leading-bar" ] ~doc)
@@ -34,8 +38,8 @@ let indentOnce =
 
 let semiAfterProducer =
   let doc =
-    "Add a semicolon after every semicolon in traditional syntax Menhir rules \
-     (it is required in the new syntax)."
+    "Terminate every producer with a semicolon in Menhir rules written in the \
+     traditional syntax."
   in
   Arg.(value & flag & info [ "semi-after-producer" ] ~doc)
 
@@ -88,9 +92,13 @@ let cmd =
      and+ tabsize = tabsize
      and+ indentOnce = indentOnce
      and+ noLeadingBar = noLeadingBar
+     and+ maxWidth = maxColumns
+     and+ breakLongRegexps = breakLongRegexps
+     and+ breakRegexpsGroups = breakRegexpsGroups
      and+ semiAfterProducer = semiAfterProducer in
      let config =
-       Config.make ~tabsize ~indentOnce ~noLeadingBar ~semiAfterProducer ()
+       Config.make ~tabsize ~indentOnce ~noLeadingBar ~semiAfterProducer
+         ~maxWidth ~breakLongRegexps ()
      in
      main ~config input_file
 

--- a/prettyprint/menhir.ml
+++ b/prettyprint/menhir.ml
@@ -87,12 +87,12 @@ class formatter ({ tabsize; _ } as cfg : Config.t) =
     method! visit_DTokenProperties =
       fun _ located associativity _precedence_level ->
         super#visit_associativity () associativity
-        ^-^ separate_map (break 1) self#visit_loctext located
+        ^-^ flow_map (break 1) self#visit_loctext located
 
     method! visit_DOnErrorReduce =
       fun _ parameters _on_error_reduce_level ->
         text "%on_error_reduce"
-        ^-^ separate_map (break 1)
+        ^-^ flow_map (break 1)
               (self#with_located @@ self#visit_parameter ())
               parameters
 
@@ -176,6 +176,7 @@ class formatter ({ tabsize; _ } as cfg : Config.t) =
             self#with_located (self#visit_identifier ()) ident ^-^ equals)
           ident
         ^-^ self#visit_parameter_loc () param
+        ^^ if_ ~then_:semi cfg.semiAfterProducer
         ^-^ self#visit_attributes () attrs
 
     method! visit_producer =

--- a/prettyprint/menhir.ml
+++ b/prettyprint/menhir.ml
@@ -19,9 +19,10 @@ end)
     method plus = ( ^^ )
   end *)
 
-class formatter (config : Config.t) =
-  let Config.{ tabsize } = config in
+class formatter ({ tabsize; _ } as cfg : Config.t) =
   let open Syntax in
+  let tabsize = max 2 tabsize in
+  let barspace = bar ^^ blank 1 in
   object (self)
     inherit [_] ast_reduce as super
     method zero : document = empty
@@ -205,9 +206,11 @@ class formatter (config : Config.t) =
         ^-^ self#visit_loctext pr_nt
         ^^ self#visit_rule_args pr_parameters
         ^^ colon)
-        ^^ nest tabsize @@ hardline
-        ^^ self#visit_old_rule_branches pr_branches
-        ^/^ self#visit_attributes () pr_attributes
+        ^^ (fun doc -> if cfg.indentOnce then nest tabsize doc else doc)
+             (hardline
+             ^^ (if cfg.noLeadingBar then blank 2 else barspace)
+             ^^ self#visit_old_rule_branches pr_branches
+             ^/^ self#visit_attributes () pr_attributes)
 
     method private visit_rule_args =
       surround_separate_map tabsize 0 empty lparen
@@ -215,23 +218,22 @@ class formatter (config : Config.t) =
         rparen self#visit_loctext
 
     method private visit_old_rule_branches branches =
-      separate_map hardline
+      separate_map (hardline ^^ barspace)
         (self#with_located (fun branch ->
              self#visit_parameterized_branch () branch))
         branches
 
     method! visit_early_production =
       fun _ (producers, prec_annotation, _) ->
-        bar
-        ^-^ flow_map (break 1)
-              (self#with_located (self#visit_early_producer ()))
-              producers
+        flow_map (break 1)
+          (self#with_located (self#visit_early_producer ()))
+          producers
         ^/^ self#visit_prec_annotation () prec_annotation
 
     method! visit_parameterized_branch =
       fun _ { pb_productions; pb_action; pb_prec_annotation; pb_attributes } ->
         nest tabsize @@ group
-        @@ separate_map hardline
+        @@ separate_map (hardline ^^ barspace)
              (self#with_located (self#visit_early_production ()))
              pb_productions
         ^/^ separate (break 1)

--- a/prettyprint/menhir.ml
+++ b/prettyprint/menhir.ml
@@ -358,5 +358,5 @@ let main ~config ~ast ~doc =
   in
   attach_comments ast (attach_vtor#visit_main ()) ~bag_of_comments ~doc
   |> (new formatter config)#visit_main ()
-  |> PPrint.ToBuffer.pretty 0.8 80 buf;
+  |> PPrint.ToBuffer.pretty 0.8 config.Config.maxWidth buf;
   Buffer.contents buf

--- a/prettyprint/menhir.ml
+++ b/prettyprint/menhir.ml
@@ -245,11 +245,35 @@ class formatter (config : Config.t) =
       code |> Ocamlformat_client.format |> R.get_or ~default:code |> String.trim
       |> arbitrary_string
 
-    method! visit_action _ expr =
+    method! visit_action _ action =
+      let module StringMap = Map.Make (String) in
+      let posvars =
+        Keyword.KeywordSet.fold
+          (fun (Keyword.Position (text, _, _, _) as k) acc ->
+            StringMap.add (Keyword.kposvar k) text acc)
+          action.keywords StringMap.empty
+      in
+
       surround tabsize 1 lbrace
-        (match expr with
-        | IL.ETextual located -> self#with_located self#visit_ocaml located
-        | _ -> text "")
+        (match action.expr with
+        | IL.ETextual located ->
+            self#with_located
+              (fun code ->
+                code |> Ocamlformat_client.format |> R.get_or ~default:code
+                |> String.trim
+                   (* 1. Recover ocamlyacc-style binders ($0, $1, ...)
+                  We simply replace _i with $i where i is a number in [0-9].
+                  This is a safe operation if we assume the user is a sane person who doesn't name her OCaml constants _0, _1 and the like. *)
+                |> Re.Str.(global_replace (regexp "\\b_\\([0-9]\\)\\b") "$\\1")
+                |>
+                (* 2. Recover Menhir keywords ($startpos, $endpos, ...) *)
+                StringMap.fold
+                  (fun var original_text ->
+                    CCString.replace ~which:`All ~sub:var ~by:original_text)
+                  posvars
+                |> arbitrary_string)
+              located
+        | _ -> text "menhirformat: unrecognized syntax")
         rbrace
 
     method! visit_prec_annotation _ =

--- a/prettyprint/menhir.ml
+++ b/prettyprint/menhir.ml
@@ -246,14 +246,6 @@ class formatter (config : Config.t) =
       |> arbitrary_string
 
     method! visit_action _ action =
-      let module StringMap = Map.Make (String) in
-      let posvars =
-        Keyword.KeywordSet.fold
-          (fun (Keyword.Position (text, _, _, _) as k) acc ->
-            StringMap.add (Keyword.kposvar k) text acc)
-          action.keywords StringMap.empty
-      in
-
       surround tabsize 1 lbrace
         (match action.expr with
         | IL.ETextual located ->
@@ -266,11 +258,14 @@ class formatter (config : Config.t) =
                   This is a safe operation if we assume the user is a sane person who doesn't name her OCaml constants _0, _1 and the like. *)
                 |> Re.Str.(global_replace (regexp "\\b_\\([0-9]\\)\\b") "$\\1")
                 |>
-                (* 2. Recover Menhir keywords ($startpos, $endpos, ...) *)
-                StringMap.fold
-                  (fun var original_text ->
-                    CCString.replace ~which:`All ~sub:var ~by:original_text)
-                  posvars
+                (* 2. Recover Menhir keywords ($startpos, $endpos, ...).
+                We fold the list of keywords from the right to follow the order in which they were scanned, and replace the leftmost occurrence for each one (i.e. ~which:`Left). *)
+                List.fold_right
+                  (fun (Keyword.Position (text, _, _, _) as k) ->
+                    CCString.replace ~which:`Left ~sub:(Keyword.kposvar k)
+                      ~by:text.v)
+                  action.keyword_lst
+                (* [action.keyword_lst] holds the keywords in the order they are scanned, reversed. *)
                 |> arbitrary_string)
               located
         | _ -> text "menhirformat: unrecognized syntax")

--- a/prettyprint/menhir.ml
+++ b/prettyprint/menhir.ml
@@ -19,7 +19,8 @@ end)
     method plus = ( ^^ )
   end *)
 
-class formatter =
+class formatter (config : Config.t) =
+  let Config.{ tabsize } = config in
   let open Syntax in
   object (self)
     inherit [_] ast_reduce as super
@@ -100,18 +101,18 @@ class formatter =
 
     method! visit_DStart =
       fun _ ocamltype located ->
-        prefix 2 1 (text "%start")
+        prefix tabsize 1 (text "%start")
           (optional (self#visit_ocamltype ()) ocamltype
           ^-^ flow_map (break 1) self#visit_loctext located)
 
     method! visit_DCode =
       fun _ ->
         self#with_located (fun code ->
-            surround 2 1 (text "%{") (self#visit_ocaml code) (text "%}"))
+            surround tabsize 1 (text "%{") (self#visit_ocaml code) (text "%}"))
 
     method! visit_DType =
       fun _ ocamltype parameter ->
-        prefix 2 1 (text "%type")
+        prefix tabsize 1 (text "%type")
           (self#visit_ocamltype () ocamltype
           ^-^ flow_map (break 1)
                 (self#with_located @@ super#visit_parameter ())
@@ -128,13 +129,13 @@ class formatter =
       fun _ located parameters ->
         self#visit_loctext
           located (* ^^ align --- only if subtree is ParamAnon *)
-        ^^ surround 2 0 lparen
+        ^^ surround tabsize 0 lparen
              (separate_map (text ",") (self#visit_parameter_loc ()) parameters)
              rparen
 
     method! visit_DToken =
       fun _ ocamltype data ->
-        prefix 2 1 (text "%token")
+        prefix tabsize 1 (text "%token")
         @@ flow (break 1)
              [
                optional (self#visit_ocamltype ()) ocamltype;
@@ -151,7 +152,7 @@ class formatter =
 
     method! visit_ocamltype =
       fun _ ocamltype ->
-        surround 2 0 langle (super#visit_ocamltype () ocamltype) rangle
+        surround tabsize 0 langle (super#visit_ocamltype () ocamltype) rangle
 
     method! visit_Declared _ = self#with_located self#visit_ocaml
     method! visit_Inferred _ = self#visit_ocaml
@@ -204,12 +205,12 @@ class formatter =
         ^-^ self#visit_loctext pr_nt
         ^^ self#visit_rule_args pr_parameters
         ^^ colon)
-        ^^ nest 2 @@ hardline
+        ^^ nest tabsize @@ hardline
         ^^ self#visit_old_rule_branches pr_branches
         ^/^ self#visit_attributes () pr_attributes
 
     method private visit_rule_args =
-      surround_separate_map 2 0 empty lparen
+      surround_separate_map tabsize 0 empty lparen
         (comma ^^ break 1)
         rparen self#visit_loctext
 
@@ -229,7 +230,7 @@ class formatter =
 
     method! visit_parameterized_branch =
       fun _ { pb_productions; pb_action; pb_prec_annotation; pb_attributes } ->
-        nest 2 @@ group
+        nest tabsize @@ group
         @@ separate_map hardline
              (self#with_located (self#visit_early_production ()))
              pb_productions
@@ -245,7 +246,7 @@ class formatter =
       |> arbitrary_string
 
     method! visit_action _ expr =
-      surround 2 1 lbrace
+      surround tabsize 1 lbrace
         (match expr with
         | IL.ETextual located -> self#with_located self#visit_ocaml located
         | _ -> text "")
@@ -269,7 +270,7 @@ class formatter =
         ^-^ text "let"
         ^-^ (self#visit_loctext pr_nt ^^ self#visit_rule_args pr_parameters)
         ^-^ if_ pr_inline ~then_:(text "==") ~else_:(text ":="))
-        ^^ nest 2
+        ^^ nest tabsize
              (hardline ^^ twice space
              ^^ self#visit_expression () pr_branches
              ^/^ self#visit_attributes () pr_attributes)
@@ -283,7 +284,7 @@ class formatter =
     method! visit_SemPatVar _ = self#visit_loctext
 
     method! visit_XAPointFree _ a =
-      surround 2 0 langle (optional self#visit_loctext a) rangle
+      surround tabsize 0 langle (optional self#visit_loctext a) rangle
 
     method! visit_XATraditional = self#visit_action
 
@@ -317,14 +318,14 @@ class formatter =
       ^^ (match list with
         | [] -> empty
         | _ :: _ ->
-            surround 2 0 lparen
+            surround tabsize 0 lparen
               (separate_map (text ", ") (self#visit_expression ()) list)
               rparen)
       ^/^ self#visit_attributes () attributes
   end
 
 (* This should really go in comment_location, but I couldn't figure out how to generalize it over the endo visitor :/ *)
-let main ~ast ~doc =
+let main ~config ~ast ~doc =
   let buf = Buffer.create 80 in
   let bag_of_comments = Lexer.get_comments () |> init_bag in
   let attach_vtor =
@@ -334,6 +335,6 @@ let main ~ast ~doc =
     end
   in
   attach_comments ast (attach_vtor#visit_main ()) ~bag_of_comments ~doc
-  |> (new formatter)#visit_main ()
+  |> (new formatter config)#visit_main ()
   |> PPrint.ToBuffer.pretty 0.8 80 buf;
   Buffer.contents buf

--- a/prettyprint/ocamllex.ml
+++ b/prettyprint/ocamllex.ml
@@ -43,9 +43,7 @@ class formatter (config : Config.t) =
       self#with_located (fun v ->
           let v =
             match Ocamlformat_client.format (String.trim v) with
-            | Ok formatted ->
-                Printf.eprintf "[ocf] '%s' --> '%s'\n\n" v formatted;
-                formatted
+            | Ok formatted -> formatted
             | Error _ -> v
           in
           surround tabsize 1 lbrace

--- a/prettyprint/ocamllex.ml
+++ b/prettyprint/ocamllex.ml
@@ -11,7 +11,8 @@ include Comment_location.Make (struct
   (* let get_comments = Lexer.get_comments *)
 end)
 
-class formatter =
+class formatter (config : Config.t) =
+  let Config.{ tabsize } = config in
   let open Syntax in
   object (self)
     inherit [_] ast_reduce as super
@@ -47,7 +48,9 @@ class formatter =
                 formatted
             | Error _ -> v
           in
-          surround 2 1 lbrace (v |> String.trim |> arbitrary_string) rbrace)
+          surround tabsize 1 lbrace
+            (v |> String.trim |> arbitrary_string)
+            rbrace)
 
     method! visit_lexer_definition _ lexer_definition =
       let { header; entrypoints; trailer; refill_handler; named_regexps } =
@@ -72,16 +75,16 @@ class formatter =
       //// optional (self#visit_action ()) trailer
 
     method! visit_named_regexp _ { name; regexp } =
-      prefix 2 1
+      prefix tabsize 1
         (text "let" ^-^ self#with_located text name ^-^ text "=")
         (self#with_located self#visit_regexp regexp)
 
     method! visit_entry _ { name; shortest; args; clauses } =
-      prefix 2 1
+      prefix tabsize 1
         (flow space
         @@ [
              self#with_located text name;
-             nest 2 @@ flow_map (break 1) (self#with_located text) args;
+             nest tabsize @@ flow_map (break 1) (self#with_located text) args;
              equals;
              self#with_located
                ((fun v -> if v then "shortest" else "parse") >> text)
@@ -90,7 +93,7 @@ class formatter =
       @@ separate_map hardline (self#with_located (self#visit_case ())) clauses
 
     method! visit_case _ (regexp, action) =
-      bar ^-^ nest 2 @@ group
+      bar ^-^ nest tabsize @@ group
       @@ self#with_located self#visit_regexp regexp
       ^/^ self#visit_action () action
 
@@ -159,7 +162,7 @@ class formatter =
   end
 
 (* This should really go in comment_location, but I couldn't figure out how to generalize it over the endo visitor :/ *)
-let main ~ast ~doc =
+let main ~config ~ast ~doc =
   let buf = Buffer.create 80 in
   let bag_of_comments = Lexer.get_comments () |> init_bag in
   let attach_vtor =
@@ -169,6 +172,6 @@ let main ~ast ~doc =
     end
   in
   attach_comments ast (attach_vtor#visit_main ()) ~bag_of_comments ~doc
-  |> (new formatter)#visit_main ()
+  |> (new formatter config)#visit_main ()
   |> PPrint.ToBuffer.pretty 0.8 80 buf;
   Buffer.contents buf

--- a/prettyprint/ocamllex.ml
+++ b/prettyprint/ocamllex.ml
@@ -203,5 +203,5 @@ let main ~config ~ast ~doc =
   in
   attach_comments ast (attach_vtor#visit_main ()) ~bag_of_comments ~doc
   |> (new formatter config)#visit_main ()
-  |> PPrint.ToBuffer.pretty 0.8 80 buf;
+  |> PPrint.ToBuffer.pretty 0.8 config.Config.maxWidth buf;
   Buffer.contents buf

--- a/prettyprint/ocamllex.ml
+++ b/prettyprint/ocamllex.ml
@@ -11,6 +11,9 @@ include Comment_location.Make (struct
   (* let get_comments = Lexer.get_comments *)
 end)
 
+let group_lvl = ref 0
+let in_case = ref false
+
 class formatter ({ tabsize; _ } as cfg : Config.t) =
   let open Syntax in
   object (self)
@@ -77,22 +80,33 @@ class formatter ({ tabsize; _ } as cfg : Config.t) =
         (self#with_located self#visit_regexp regexp)
 
     method! visit_entry _ { name; shortest; args; clauses } =
-      (if cfg.indentOnce then prefix tabsize 1 else ( ^/^ ))
-        (flow space
-        @@ [
-             self#with_located text name;
-             nest tabsize @@ flow_map (break 1) (self#with_located text) args;
-             equals;
-             self#with_located
-               ((fun v -> if v then "shortest" else "parse") >> text)
-               shortest;
-           ])
-      @@ separate_map hardline (self#with_located (self#visit_case ())) clauses
+      flow (blank 1)
+      @@ [
+           self#with_located text name;
+           nest tabsize @@ flow_map (break 1) (self#with_located text) args;
+           equals;
+           prefix
+             (if cfg.indentOnce then tabsize else 0)
+             1
+             (self#with_located
+                ((fun v -> if v then "shortest" else "parse") >> text)
+                shortest)
+           @@ separate_mapi (break 1)
+                (fun i loc ->
+                  ifflat empty
+                    (if_ ~then_:(blank 2) ~else_:barspace
+                       (i = 0 && cfg.noLeadingBar))
+                  ^^ self#with_located (self#visit_case ()) loc)
+                clauses;
+         ]
 
     method! visit_case _ (regexp, action) =
-      bar ^-^ nest tabsize @@ group
-      @@ self#with_located self#visit_regexp regexp
-      ^/^ self#visit_action () action
+      prefix tabsize 1
+        (in_case := true;
+         let doc = self#with_located self#visit_regexp regexp in
+         in_case := false;
+         doc)
+        (self#visit_action () action)
 
     method! visit_Wildcard _ = self#with_located (fun _ -> text "_")
     method! visit_EOF _ = self#with_located (fun _ -> text "eof")
@@ -104,17 +118,30 @@ class formatter ({ tabsize; _ } as cfg : Config.t) =
     method! visit_String _ = self#with_located (text >> dquotes)
     method! visit_Ref _ = self#with_located text
 
-    (* todo: let the user decide whether to break the regexp onto multiple lines
-    if it doesn't fit in one (by default, we only break alternations) *)
     method! visit_Seq _ re1 re2 =
-      self#with_located self#visit_regexp re1
-      ^-^ self#with_located self#visit_regexp re2
+      let cond =
+        cfg.breakLongRegexps && (cfg.breakRegexpGroups || !group_lvl = 0)
+      in
+      if_
+        ~then_:
+          (* (self#with_located self#visit_regexp re1
+          ^^ group (break 1 ^| self#with_located self#visit_regexp re2)) *)
+          (* (group (self#with_located self#visit_regexp re1 |^ break 1)
+          ^^ self#with_located self#visit_regexp re2) *)
+          (self#with_located self#visit_regexp re1
+          |^ group (nest tabsize (break 1))
+             ^| self#with_located self#visit_regexp re2)
+        ~else_:
+          (self#with_located self#visit_regexp re1
+          ^-^ self#with_located self#visit_regexp re2)
+        cond
 
     method! visit_Alt _ re1 re2 =
-      group @@ align
-      @@ self#with_located self#visit_regexp re1
-      ^/^ bar
-      ^-^ self#with_located self#visit_regexp re2
+      (* Arrange the alternatives in a box only inside groups or in [let] definitions *)
+      (if (not !in_case) || !group_lvl <> 0 then align else fun x -> x)
+      @@ (self#with_located self#visit_regexp re1
+         |^ group (break 1 ^^ barspace)
+            ^| self#with_located self#visit_regexp re2)
 
     method! visit_CharSetDifference _ re1 re2 =
       group @@ align
@@ -134,7 +161,13 @@ class formatter ({ tabsize; _ } as cfg : Config.t) =
     method! visit_Group _ =
       self#with_located (function
         | Group re -> self#visit_Group () re (* already grouped *)
-        | re -> enclose lparen (self#visit_regexp re) rparen)
+        | re ->
+            enclose lparen
+              (incr group_lvl;
+               let doc = self#visit_regexp re in
+               decr group_lvl;
+               doc)
+              rparen)
 
     method! visit_As _ re ident =
       (* To get a better idea of what is being captured, we could surround alternation and sequences with parens. *)

--- a/prettyprint/ocamllex.ml
+++ b/prettyprint/ocamllex.ml
@@ -11,8 +11,7 @@ include Comment_location.Make (struct
   (* let get_comments = Lexer.get_comments *)
 end)
 
-class formatter (config : Config.t) =
-  let Config.{ tabsize } = config in
+class formatter ({ tabsize; _ } as cfg : Config.t) =
   let open Syntax in
   object (self)
     inherit [_] ast_reduce as super
@@ -78,7 +77,7 @@ class formatter (config : Config.t) =
         (self#with_located self#visit_regexp regexp)
 
     method! visit_entry _ { name; shortest; args; clauses } =
-      prefix tabsize 1
+      (if cfg.indentOnce then prefix tabsize 1 else ( ^/^ ))
         (flow space
         @@ [
              self#with_located text name;

--- a/prettyprint/utils.ml
+++ b/prettyprint/utils.ml
@@ -1,14 +1,17 @@
 include Menhir_lsp_lib.Utils
 
 module Config = struct
-  type t = { tabsize : int; noLeadingBar : bool; indentOnce : bool }
-  (** Represents common formatting options. *)
+  type t = {
+    tabsize : int; [@default 2]
+    noLeadingBar : bool; [@default false]
+    indentOnce : bool; [@default false]
+    semiAfterProducer : bool; [@default false]
+    breakLongRegexps : bool; [@default true]
+  }
+  [@@deriving make]
+  (** Represents the formatting options to customize the output. *)
 
-  let default_config : t =
-    { tabsize = 2; noLeadingBar = false; indentOnce = false }
-
-  let make ~tabsize ~noLeadingBar ~indentOnce : t =
-    { tabsize; noLeadingBar; indentOnce }
+  let default_config : t = make ()
 end
 
 module PPrint = struct

--- a/prettyprint/utils.ml
+++ b/prettyprint/utils.ml
@@ -1,16 +1,21 @@
 include Menhir_lsp_lib.Utils
 
 module Config = struct
-  type t = { tabsize : int }
+  type t = { tabsize : int; noLeadingBar : bool; indentOnce : bool }
   (** Represents common formatting options. *)
 
-  let make ~tabsize : t = { tabsize }
+  let default_config : t =
+    { tabsize = 2; noLeadingBar = false; indentOnce = false }
+
+  let make ~tabsize ~noLeadingBar ~indentOnce : t =
+    { tabsize; noLeadingBar; indentOnce }
 end
 
 module PPrint = struct
   include PPrint
 
   let text = string
+  let escaped = String.escaped >> arbitrary_string
 
   let between sep d1 d2 =
     match (is_empty d1, is_empty d2) with
@@ -57,3 +62,10 @@ module PPrint = struct
   let barspace = text "| "
   let enclose l x r = enclose l r x
 end
+
+let doc_of_string ?(input_file = "") text : TD.t =
+  TD.make ~position_encoding:`UTF8
+    {
+      textDocument =
+        { languageId = ""; text; uri = Uri.of_path input_file; version = 0 };
+    }

--- a/prettyprint/utils.ml
+++ b/prettyprint/utils.ml
@@ -1,5 +1,12 @@
 include Menhir_lsp_lib.Utils
 
+module Config = struct
+  type t = { tabsize : int }
+  (** Represents common formatting options. *)
+
+  let make ~tabsize : t = { tabsize }
+end
+
 module PPrint = struct
   include PPrint
 

--- a/prettyprint/utils.ml
+++ b/prettyprint/utils.ml
@@ -3,14 +3,15 @@ include Menhir_lsp_lib.Utils
 module Config = struct
   type t = {
     tabsize : int; [@default 2]
+    maxWidth : int; [@default 80]
     noLeadingBar : bool; [@default false]
     indentOnce : bool; [@default false]
     semiAfterProducer : bool; [@default false]
     breakLongRegexps : bool; [@default false]
     breakRegexpGroups : bool; [@default false]
   }
-  [@@deriving make]
-  (** Represents the formatting options to customize the output. *)
+  [@@deriving make, yojson]
+  (** The formatting options to customize the output of [menhirformat]. *)
 
   let default_config : t = make ()
 end

--- a/prettyprint/utils.ml
+++ b/prettyprint/utils.ml
@@ -6,7 +6,8 @@ module Config = struct
     noLeadingBar : bool; [@default false]
     indentOnce : bool; [@default false]
     semiAfterProducer : bool; [@default false]
-    breakLongRegexps : bool; [@default true]
+    breakLongRegexps : bool; [@default false]
+    breakRegexpGroups : bool; [@default false]
   }
   [@@deriving make]
   (** Represents the formatting options to customize the output. *)
@@ -33,11 +34,11 @@ module PPrint = struct
   let ( <|> ) d e = if is_empty d then e else d
   let ( <!> ) d e = if is_empty d then empty else e
 
-  (** Prefix [sep] to [d] if [d] is nonempty. *)
-  let ( ^! ) sep d = d <!> sep ^^ d
+  (** [sep ^| d] prepends [sep] to [d] if [d] is nonempty. *)
+  let ( ^| ) sep d = d <!> sep ^^ d
 
-  (** Append [sep] to [d] if [d] is nonempty. *)
-  let ( !^ ) d sep = d <!> d ^^ sep
+  (** [d |^ sep] appends [sep] to [d] if [d] is nonempty. *)
+  let ( |^ ) d sep = d <!> d ^^ sep
 
   (** A smarter [separate_map] that doesn't insert [sep] if either side is
       empty. *)
@@ -57,10 +58,20 @@ module PPrint = struct
         let doc' = f doc in
         if i = 0 then doc'
         else if is_empty accu then doc'
-        else accu ^^ group (sep ^! doc'))
+        else accu ^^ group (sep ^| doc'))
+      empty docs
+
+  let flow_right_map sep f docs =
+    L.foldi
+      (fun accu i doc ->
+        let doc' = f doc in
+        if i = 0 then doc'
+        else if is_empty accu then doc'
+        else group (accu |^ sep) ^^ doc')
       empty docs
 
   let flow sep = flow_map sep (fun x -> x)
+  let flow_right sep = flow_right_map sep (fun x -> x)
   let if_ ?(else_ = empty) ~then_ b = if b then then_ else else_
   let barspace = text "| "
   let enclose l x r = enclose l r x

--- a/test/menhirformat/dune
+++ b/test/menhirformat/dune
@@ -1,0 +1,6 @@
+(library
+ (name menhirformat_test)
+ (inline_tests)
+ (libraries menhirformat_lib menhirSyntax ocamllexSyntax)
+ (preprocess
+  (pps ppx_expect)))

--- a/test/menhirformat/menhir_tests.ml
+++ b/test/menhirformat/menhir_tests.ml
@@ -22,7 +22,7 @@ let helper text : unit =
                       version = 0;
                     };
                 }))
-       ~error:(fun _ -> "parser error")
+       ~error:(fun (msg, range) -> spr "%s at %s" msg (Mly.Range.show range))
   |> print_endline
 
 let%expect_test "It can handle the new syntax" =
@@ -62,10 +62,18 @@ let%expect_test "It preserves $ and position keywords in semantic actions" =
 
 main: FOO { ($1, $loc($1)) }
 
-rule_S: FOO; list(FOO) { ($2, $symbolstartpos) }
+rule_S: FOO; k = list(FOO) { ($loc(k),  $endpos(k), $sloc, $startpos(k)) }
+
+declaration:
+| h = HEADER /* lexically delimited by %{ ... %} */
+    { locate' $loc @@ DCode h |> singleton }
+| k = priority_keyword ss = clist(symbol)
+    {
+      let _ = $loc, $sloc in
+      let prec = ParserAux.new_precedence_level $loc(k) in
+      locate' $loc(k) @@ DTokenProperties (ss, k, prec) |> singleton }
 |};
-  [%expect
-    {|
+  [%expect {|
     %token FOO
 
     %start <int, Lexing.position> main
@@ -76,5 +84,15 @@ rule_S: FOO; list(FOO) { ($2, $symbolstartpos) }
       | FOO { $1, $loc($1) }
 
     rule_S:
-      | FOO list(FOO) { $2, $symbolstartpos }
+      | FOO k = list(FOO) { $loc(k), $endpos(k), $sloc, $startpos(k) }
+
+    declaration:
+      | h = HEADER /* lexically delimited by %{ ... %} */
+        { locate' $loc @@ DCode h |> singleton }
+      | k = priority_keyword ss = clist(symbol)
+        {
+          let _ = ($loc, $sloc) in
+          let prec = ParserAux.new_precedence_level $loc(k) in
+          locate' $loc(k) @@ DTokenProperties (ss, k, prec) |> singleton
+        }
     |}]

--- a/test/menhirformat/menhir_tests.ml
+++ b/test/menhirformat/menhir_tests.ml
@@ -61,10 +61,8 @@ let%expect_test "It can format the traditional syntax" =
 
     %type <int> expr
 
-    %left PLUS
-    MINUS /* lowest precedence */
-    %left TIMES
-    DIV /* medium precedence */
+    %left PLUS MINUS /* lowest precedence */
+    %left TIMES DIV /* medium precedence */
     %nonassoc UMINUS /* highest precedence */
 
     %%
@@ -82,10 +80,9 @@ let%expect_test "It can format the traditional syntax" =
     | MINUS e = expr %prec UMINUS { -e }
     |}]
 
-let%expect_test "The [noLeadingBar] option works" =
-  helper ~config:{ default_config with noLeadingBar = true } calc_demo;
-  [%expect
-    {|
+let%expect_test "The [separateProducers] option works" =
+  helper ~config:{ default_config with semiAfterProducer = true } calc_demo;
+  [%expect {|
     %token <int> INT
     %token PLUS MINUS TIMES DIV
     %token LPAREN RPAREN
@@ -95,25 +92,23 @@ let%expect_test "The [noLeadingBar] option works" =
 
     %type <int> expr
 
-    %left PLUS
-    MINUS /* lowest precedence */
-    %left TIMES
-    DIV /* medium precedence */
+    %left PLUS MINUS /* lowest precedence */
+    %left TIMES DIV /* medium precedence */
     %nonassoc UMINUS /* highest precedence */
 
     %%
 
     main:
-      e = expr EOL { e }
+    | e = expr; EOL; { e }
 
     expr:
-      i = INT { i }
-    | LPAREN e = expr RPAREN { e }
-    | e1 = expr PLUS e2 = expr { e1 + e2 }
-    | e1 = expr MINUS e2 = expr { e1 - e2 }
-    | e1 = expr TIMES e2 = expr { e1 * e2 }
-    | e1 = expr DIV e2 = expr { e1 / e2 }
-    | MINUS e = expr %prec UMINUS { -e }
+    | i = INT; { i }
+    | LPAREN; e = expr; RPAREN; { e }
+    | e1 = expr; PLUS; e2 = expr; { e1 + e2 }
+    | e1 = expr; MINUS; e2 = expr; { e1 - e2 }
+    | e1 = expr; TIMES; e2 = expr; { e1 * e2 }
+    | e1 = expr; DIV; e2 = expr; { e1 / e2 }
+    | MINUS; e = expr; %prec UMINUS { -e }
     |}]
 
 let%expect_test "The [indentOnce] option works" =
@@ -131,10 +126,8 @@ let%expect_test "The [indentOnce] option works" =
 
     %type <int> expr
 
-    %left PLUS
-    MINUS /* lowest precedence */
-    %left TIMES
-    DIV /* medium precedence */
+    %left PLUS MINUS /* lowest precedence */
+    %left TIMES DIV /* medium precedence */
     %nonassoc UMINUS /* highest precedence */
 
     %%

--- a/test/menhirformat/menhir_tests.ml
+++ b/test/menhirformat/menhir_tests.ml
@@ -1,0 +1,79 @@
+open Menhirformat_lib
+open Utils
+module M = MenhirSyntax
+module MF = Menhir
+
+let config : Config.t = { tabsize = 2 }
+
+let format_str text : unit =
+  text
+  |> M.Main.load_grammar_from_contents 0 ""
+  |> Result.fold
+       ~ok:(fun partial_grammar ->
+         MF.main ~config ~ast:partial_grammar
+           ~doc:
+             (TD.make ~position_encoding:`UTF8
+                {
+                  textDocument =
+                    {
+                      languageId = "";
+                      text;
+                      uri = Uri.of_path "foo/bar";
+                      version = 0;
+                    };
+                }))
+       ~error:(fun _ -> "parser error")
+  |> print_endline
+
+let%expect_test "It can handle the new syntax" =
+  format_str
+    {|%token FOO
+%token BAR
+%token BAZ
+%%
+
+let main == expr; EOF; { () }
+
+let expr := expr; BAR; expr; <Bar> | FOO; <Foo>
+|};
+  [%expect
+    {|
+    %token FOO
+    %token BAR
+    %token BAZ
+
+    %%
+
+    let main ==
+        expr; EOF; { () }
+
+    let expr :=
+        expr; BAR; expr; <Bar>
+      | FOO; <Foo>
+    |}]
+
+let%expect_test "It preserves $ and position keywords in semantic actions" =
+  format_str
+    {|%token FOO
+
+%start <int, Lexing.position> main
+
+%%
+
+main: FOO { ($1, $loc($1)) }
+
+rule_S: FOO; list(FOO) { ($2, $symbolstartpos) }
+|};
+  [%expect {|
+    %token FOO
+
+    %start <int, Lexing.position> main
+
+    %%
+
+    main:
+      | FOO { $1, $loc($1) }
+
+    rule_S:
+      | FOO list(FOO) { $2, $symbolstartpos }
+    |}]

--- a/test/menhirformat/menhir_tests.ml
+++ b/test/menhirformat/menhir_tests.ml
@@ -1,29 +1,156 @@
 open Menhirformat_lib
 open Utils
+open Config
 module Mly = MenhirSyntax
 module MF = Menhir
 
-let config : Config.t = { tabsize = 2 }
-
-let helper text : unit =
+let helper ?(config : Config.t = default_config) text : unit =
   text
   |> MenhirSyntax.Main.load_grammar_from_contents 0 ""
   |> Result.fold
-       ~ok:(fun partial_grammar ->
-         MF.main ~config ~ast:partial_grammar
-           ~doc:
-             (TD.make ~position_encoding:`UTF8
-                {
-                  textDocument =
-                    {
-                      languageId = "";
-                      text;
-                      uri = Uri.of_path "foo/bar";
-                      version = 0;
-                    };
-                }))
+       ~ok:(fun ast -> MF.main ~config ~ast ~doc:(doc_of_string text))
        ~error:(fun (msg, range) -> spr "%s at %s" msg (Mly.Range.show range))
   |> print_endline
+
+let calc_demo =
+  {|%token <int> INT
+%token PLUS MINUS TIMES DIV
+%token LPAREN RPAREN
+%token EOL
+
+%left PLUS MINUS        /* lowest precedence */
+%left TIMES DIV         /* medium precedence */
+%nonassoc UMINUS        /* highest precedence */
+
+%start <int> main
+%type  <int> expr
+
+%%
+
+main:
+| e = expr EOL
+    { e }
+
+expr:
+| i = INT
+    { i }
+| LPAREN e = expr RPAREN
+    { e }
+| e1 = expr PLUS e2 = expr
+    { e1 + e2 }
+| e1 = expr MINUS e2 = expr
+    { e1 - e2 }
+| e1 = expr TIMES e2 = expr
+    { e1 * e2 }
+| e1 = expr DIV e2 = expr
+    { e1 / e2 }
+| MINUS e = expr %prec UMINUS
+    { - e }
+|}
+
+let%expect_test "It can format the traditional syntax" =
+  helper calc_demo;
+  [%expect
+    {|
+    %token <int> INT
+    %token PLUS MINUS TIMES DIV
+    %token LPAREN RPAREN
+    %token EOL
+
+    %start <int> main
+
+    %type <int> expr
+
+    %left PLUS
+    MINUS /* lowest precedence */
+    %left TIMES
+    DIV /* medium precedence */
+    %nonassoc UMINUS /* highest precedence */
+
+    %%
+
+    main:
+    | e = expr EOL { e }
+
+    expr:
+    | i = INT { i }
+    | LPAREN e = expr RPAREN { e }
+    | e1 = expr PLUS e2 = expr { e1 + e2 }
+    | e1 = expr MINUS e2 = expr { e1 - e2 }
+    | e1 = expr TIMES e2 = expr { e1 * e2 }
+    | e1 = expr DIV e2 = expr { e1 / e2 }
+    | MINUS e = expr %prec UMINUS { -e }
+    |}]
+
+let%expect_test "The [noLeadingBar] option works" =
+  helper ~config:{ default_config with noLeadingBar = true } calc_demo;
+  [%expect
+    {|
+    %token <int> INT
+    %token PLUS MINUS TIMES DIV
+    %token LPAREN RPAREN
+    %token EOL
+
+    %start <int> main
+
+    %type <int> expr
+
+    %left PLUS
+    MINUS /* lowest precedence */
+    %left TIMES
+    DIV /* medium precedence */
+    %nonassoc UMINUS /* highest precedence */
+
+    %%
+
+    main:
+      e = expr EOL { e }
+
+    expr:
+      i = INT { i }
+    | LPAREN e = expr RPAREN { e }
+    | e1 = expr PLUS e2 = expr { e1 + e2 }
+    | e1 = expr MINUS e2 = expr { e1 - e2 }
+    | e1 = expr TIMES e2 = expr { e1 * e2 }
+    | e1 = expr DIV e2 = expr { e1 / e2 }
+    | MINUS e = expr %prec UMINUS { -e }
+    |}]
+
+let%expect_test "The [indentOnce] option works" =
+  helper
+    ~config:{ default_config with tabsize = 4; indentOnce = true }
+    calc_demo;
+  [%expect
+    {|
+    %token <int> INT
+    %token PLUS MINUS TIMES DIV
+    %token LPAREN RPAREN
+    %token EOL
+
+    %start <int> main
+
+    %type <int> expr
+
+    %left PLUS
+    MINUS /* lowest precedence */
+    %left TIMES
+    DIV /* medium precedence */
+    %nonassoc UMINUS /* highest precedence */
+
+    %%
+
+    main:
+        | e = expr EOL { e }
+
+    expr:
+        | i = INT { i }
+        | LPAREN e = expr RPAREN { e }
+        | e1 = expr PLUS e2 = expr { e1 + e2 }
+        | e1 = expr MINUS e2 = expr { e1 - e2 }
+        | e1 = expr TIMES e2 = expr { e1 * e2 }
+        | e1 = expr DIV e2 = expr { e1 / e2 }
+        | MINUS e = expr %prec UMINUS { -e }
+    |}]
 
 let%expect_test "It can handle the new syntax" =
   helper
@@ -52,7 +179,7 @@ let expr := expr; BAR; expr; <Bar> | FOO; <Foo>
       | FOO; <Foo>
     |}]
 
-let%expect_test "It preserves $ and position keywords in semantic actions" =
+let%expect_test "It preserves $'s and position keywords in semantic actions" =
   helper
     {|%token FOO
 
@@ -73,7 +200,8 @@ declaration:
       let prec = ParserAux.new_precedence_level $loc(k) in
       locate' $loc(k) @@ DTokenProperties (ss, k, prec) |> singleton }
 |};
-  [%expect {|
+  [%expect
+    {|
     %token FOO
 
     %start <int, Lexing.position> main
@@ -81,18 +209,18 @@ declaration:
     %%
 
     main:
-      | FOO { $1, $loc($1) }
+    | FOO { $1, $loc($1) }
 
     rule_S:
-      | FOO k = list(FOO) { $loc(k), $endpos(k), $sloc, $startpos(k) }
+    | FOO k = list(FOO) { $loc(k), $endpos(k), $sloc, $startpos(k) }
 
     declaration:
-      | h = HEADER /* lexically delimited by %{ ... %} */
-        { locate' $loc @@ DCode h |> singleton }
-      | k = priority_keyword ss = clist(symbol)
-        {
-          let _ = ($loc, $sloc) in
-          let prec = ParserAux.new_precedence_level $loc(k) in
-          locate' $loc(k) @@ DTokenProperties (ss, k, prec) |> singleton
-        }
+    | h = HEADER /* lexically delimited by %{ ... %} */
+      { locate' $loc @@ DCode h |> singleton }
+    | k = priority_keyword ss = clist(symbol)
+      {
+        let _ = ($loc, $sloc) in
+        let prec = ParserAux.new_precedence_level $loc(k) in
+        locate' $loc(k) @@ DTokenProperties (ss, k, prec) |> singleton
+      }
     |}]

--- a/test/menhirformat/menhir_tests.ml
+++ b/test/menhirformat/menhir_tests.ml
@@ -1,13 +1,13 @@
 open Menhirformat_lib
 open Utils
-module M = MenhirSyntax
+module Mly = MenhirSyntax
 module MF = Menhir
 
 let config : Config.t = { tabsize = 2 }
 
-let format_str text : unit =
+let helper text : unit =
   text
-  |> M.Main.load_grammar_from_contents 0 ""
+  |> MenhirSyntax.Main.load_grammar_from_contents 0 ""
   |> Result.fold
        ~ok:(fun partial_grammar ->
          MF.main ~config ~ast:partial_grammar
@@ -26,7 +26,7 @@ let format_str text : unit =
   |> print_endline
 
 let%expect_test "It can handle the new syntax" =
-  format_str
+  helper
     {|%token FOO
 %token BAR
 %token BAZ
@@ -53,7 +53,7 @@ let expr := expr; BAR; expr; <Bar> | FOO; <Foo>
     |}]
 
 let%expect_test "It preserves $ and position keywords in semantic actions" =
-  format_str
+  helper
     {|%token FOO
 
 %start <int, Lexing.position> main
@@ -64,7 +64,8 @@ main: FOO { ($1, $loc($1)) }
 
 rule_S: FOO; list(FOO) { ($2, $symbolstartpos) }
 |};
-  [%expect {|
+  [%expect
+    {|
     %token FOO
 
     %start <int, Lexing.position> main

--- a/test/menhirformat/ocamllex_tests.ml
+++ b/test/menhirformat/ocamllex_tests.ml
@@ -3,24 +3,11 @@ open Utils
 module Mll = OcamllexSyntax
 module MF = Ocamllex
 
-let config : Config.t = { tabsize = 2 }
-
-let helper text : unit =
+let helper ?(config : Config.t = Config.default_config) text : unit =
   text |> Mll.Main.parse_string
   |> Result.fold
        ~ok:(fun partial_grammar ->
-         MF.main ~config ~ast:partial_grammar
-           ~doc:
-             (TD.make ~position_encoding:`UTF8
-                {
-                  textDocument =
-                    {
-                      languageId = "";
-                      text;
-                      uri = Uri.of_path "foo/bar";
-                      version = 0;
-                    };
-                }))
+         MF.main ~config ~ast:partial_grammar ~doc:(doc_of_string text))
        ~error:(fun (msg, range) -> spr "%s at %s" msg (Mll.Range.show range))
   |> print_endline
 
@@ -33,11 +20,12 @@ let%expect_test "It handles escape sequences correctly" =
   | "\\"                      { lexer_logger "\\"; Parser.LDIVIDE }
   | "\\" ("[a-z]" as c) { Printf.printf "got rare backslash sequence: \"\\%c\"\n" c}
 |};
-  [%expect {|
+  [%expect
+    {|
     rule next_token = parse
-      | "\t" | " " { next_token lexbuf }
-      | "\n" | '\n' | "\r" { Lexing.new_line () }
-      | '\\' | "\\" { lexer_logger "\\"; Parser.LDIVIDE }
-      | "\\" ("[a-z]" as c)
-        { Printf.printf "got rare backslash sequence: \"\\%c\"\n" c }
+    | "\t" | " " { next_token lexbuf }
+    | "\n" | '\n' | "\r" { Lexing.new_line () }
+    | '\\' | "\\" { lexer_logger "\\"; Parser.LDIVIDE }
+    | "\\" ("[a-z]" as c)
+      { Printf.printf "got rare backslash sequence: \"\\%c\"\n" c }
     |}]

--- a/test/menhirformat/ocamllex_tests.ml
+++ b/test/menhirformat/ocamllex_tests.ml
@@ -1,5 +1,6 @@
 open Menhirformat_lib
 open Utils
+open Config
 module Mll = OcamllexSyntax
 module MF = Ocamllex
 
@@ -14,7 +15,7 @@ let helper ?(config : Config.t = Config.default_config) text : unit =
 let%expect_test "It handles escape sequences correctly" =
   helper
     {|rule next_token = parse
-    | "\t" | "\ " {next_token lexbuf}
+  | "\t" | "\ " {next_token lexbuf}
   | "\n" | '\n' | "\r"  {Lexing.new_line ()}
   | '\\'
   | "\\"                      { lexer_logger "\\"; Parser.LDIVIDE }
@@ -28,4 +29,186 @@ let%expect_test "It handles escape sequences correctly" =
     | '\\' | "\\" { lexer_logger "\\"; Parser.LDIVIDE }
     | "\\" ("[a-z]" as c)
       { Printf.printf "got rare backslash sequence: \"\\%c\"\n" c }
+    |}]
+
+let items_demo =
+  {|let green_series_item =
+  "Green" as series (("Bed" | "Bench" | "Chair" | "Counter" | "Desk" | "Dresser" | "Lamp" | "Pantry" | "Shell" | "Table" | "Wall Clock" | "Wardrobe") as item)
+
+let bedroom_item =
+  ("Gorgeous" | "Sea-Anemone" | "Polka-Dot") as series ("Bed" as item)
+  | ("Card" | "Gorgeous" | "Jingle" | "Polka-Dot" | "Regal" | "Pear") as series ("Dresser" as item)
+  | ("Regal" | "Full-Moon") as series ("Vanity" as item)
+
+rule scan_feng_shui_item = parse
+| ("Alpinist" | "Blossoming" | "Dapper" | "Festivale" | "Festive-Tree"
+   | "Chevron" | "Green Lace-Up" | "Lime") as line (("Dress" | "Hat"
+                                                    | "Pants" | "Tank") as kind)
+  { CLOTHING (line, type) }
+| green_series_item | ("Zodiac" as series) (("Goat" | "Snake" | "Tiger"
+                                             | "Horse" | "Ox" | "Rabbit" | "Dragon") as item)
+  | ("Golden" as series) (("Bed" | "Bench" | "Chair" | "Clock" | "Closet"
+                           | "Dresser" | "Man" | "Screen" | "Table") as item)
+  { FURNITURE (series, item) }
+| ("Squat" as size) ("Nebuloid" as name) | (("Mega" | "Mini" | "Tall")? as size) (("Brewstoid" | "Buzzoid" | "Clankoid" | "Croakoid" | "Plinkoid" | "Quazoid" | "Sputnoid" | "Squelchoid") as name)
+  { GYROID (name, size) }
+| eof { EOF }
+| _ { failwith "not a feng shui item" }
+
+and green_item = parse green_series_item | "Leaf Bed" as g { g }|}
+
+let%expect_test "Test breaking of alternations" =
+  helper ~config:(Config.make ~indentOnce:true ()) items_demo;
+  [%expect
+    {|
+    let green_series_item =
+      "Green" as series (("Bed" | "Bench" | "Chair" | "Counter" | "Desk"
+                          | "Dresser" | "Lamp" | "Pantry" | "Shell" | "Table" | "Wall Clock"
+                          | "Wardrobe") as item)
+
+    let bedroom_item =
+      ("Gorgeous" | "Sea-Anemone" | "Polka-Dot") as series ("Bed" as item)
+      | ("Card" | "Gorgeous" | "Jingle" | "Polka-Dot" | "Regal" | "Pear") as series ("Dresser" as item)
+      | ("Regal" | "Full-Moon") as series ("Vanity" as item)
+
+    rule scan_feng_shui_item = parse
+      | ("Alpinist" | "Blossoming" | "Dapper" | "Festivale" | "Festive-Tree"
+         | "Chevron" | "Green Lace-Up" | "Lime") as line (("Dress" | "Hat"
+                                                           | "Pants" | "Tank") as kind)
+        { CLOTHING (line, type) }
+      | green_series_item | ("Zodiac" as series) (("Goat" | "Snake" | "Tiger"
+                                                   | "Horse" | "Ox" | "Rabbit" | "Dragon") as item)
+      | ("Golden" as series) (("Bed" | "Bench" | "Chair" | "Clock" | "Closet"
+                               | "Dresser" | "Man" | "Screen" | "Table") as item)
+        { FURNITURE (series, item) }
+      | ("Squat" as size) ("Nebuloid" as name) | (("Mega" | "Mini" | "Tall")? as size) (("Brewstoid"
+                                                                                         | "Buzzoid"
+                                                                                         | "Clankoid"
+                                                                                         | "Croakoid"
+                                                                                         | "Plinkoid"
+                                                                                         | "Quazoid"
+                                                                                         | "Sputnoid"
+                                                                                         | "Squelchoid") as name)
+        { GYROID (name, size) }
+      | eof { EOF }
+      | _ { failwith "not a feng shui item" }
+
+    and green_item = parse green_series_item | "Leaf Bed" as g { g }
+    |}]
+
+let long_regexp_demo =
+  {|rule main allow_newlines = parse
+      | [' ' '\r' '\t' '\012']+ { main allow_newlines lexbuf }
+      | '\n'
+      {
+        match allow_newlines with
+        | `AllowNewlines ->
+            Lexing.new_line lexbuf;
+            main allow_newlines lexbuf
+        | _ -> failwith "newline"
+      }
+      | "#" [' ' '\t']* (['0'-'9']+) [' ' '\t']* ('"' ([^'\n' '\r' '"']*) '"')? [^'\n' '\r']* '\r'* '\n'
+      { main allow_newlines lexbuf }
+      | "(*" { comment 0 lexbuf; main allow_newlines lexbuf }
+      | eof { () }
+      | _ { failwith "not a comment" }
+
+      and comment depth = parse
+      | "(*" { comment (depth + 1) lexbuf }
+      | "*)" { if depth > 0 then comment (depth - 1) lexbuf }
+      | eof { failwith "unterminated comment" }
+      | '\n' { Lexing.new_line lexbuf; comment depth lexbuf }
+      | _ { comment depth lexbuf }
+      |}
+
+let%expect_test "Option [breakLongRegexps] works" =
+  helper
+    ~config:{ default_config with breakLongRegexps = true }
+    long_regexp_demo;
+  [%expect
+    {|
+    rule main allow_newlines = parse
+    | [' ' '\r' '\t' '\012']+ { main allow_newlines lexbuf }
+    | '\n'
+      {
+        match allow_newlines with
+        | `AllowNewlines ->
+            Lexing.new_line lexbuf;
+            main allow_newlines lexbuf
+        | _ -> failwith "newline"
+      }
+    | "#" [' ' '\t']* (['0'-'9']+) [' ' '\t']* ('"' ([^'\n' '\r' '"']*) '"')?
+      [^'\n' '\r']* '\r'* '\n'
+      { main allow_newlines lexbuf }
+    | "(*" { comment 0 lexbuf; main allow_newlines lexbuf }
+    | eof { () }
+    | _ { failwith "not a comment" }
+
+    and comment depth = parse
+    | "(*" { comment (depth + 1) lexbuf }
+    | "*)" { if depth > 0 then comment (depth - 1) lexbuf }
+    | eof { failwith "unterminated comment" }
+    | '\n' { Lexing.new_line lexbuf; comment depth lexbuf }
+    | _ { comment depth lexbuf }
+    |}]
+
+let%expect_test "Option [breakRegexpGroups] works" =
+  helper
+    ~config:
+      { default_config with breakLongRegexps = true; breakRegexpGroups = true }
+    long_regexp_demo;
+  [%expect
+    {|
+    rule main allow_newlines = parse
+    | [' ' '\r' '\t' '\012']+ { main allow_newlines lexbuf }
+    | '\n'
+      {
+        match allow_newlines with
+        | `AllowNewlines ->
+            Lexing.new_line lexbuf;
+            main allow_newlines lexbuf
+        | _ -> failwith "newline"
+      }
+    | "#" [' ' '\t']* (['0'-'9']+) [' ' '\t']* ('"' ([^'\n' '\r' '"']*)
+      '"')? [^'\n' '\r']* '\r'* '\n'
+      { main allow_newlines lexbuf }
+    | "(*" { comment 0 lexbuf; main allow_newlines lexbuf }
+    | eof { () }
+    | _ { failwith "not a comment" }
+
+    and comment depth = parse
+    | "(*" { comment (depth + 1) lexbuf }
+    | "*)" { if depth > 0 then comment (depth - 1) lexbuf }
+    | eof { failwith "unterminated comment" }
+    | '\n' { Lexing.new_line lexbuf; comment depth lexbuf }
+    | _ { comment depth lexbuf }
+    |}];
+  helper
+    ~config:
+      { default_config with breakLongRegexps = false; breakRegexpGroups = true }
+    long_regexp_demo;
+  [%expect
+    {|
+    rule main allow_newlines = parse
+    | [' ' '\r' '\t' '\012']+ { main allow_newlines lexbuf }
+    | '\n'
+      {
+        match allow_newlines with
+        | `AllowNewlines ->
+            Lexing.new_line lexbuf;
+            main allow_newlines lexbuf
+        | _ -> failwith "newline"
+      }
+    | "#" [' ' '\t']* (['0'-'9']+) [' ' '\t']* ('"' ([^'\n' '\r' '"']*) '"')? [^'\n' '\r']* '\r'* '\n'
+      { main allow_newlines lexbuf }
+    | "(*" { comment 0 lexbuf; main allow_newlines lexbuf }
+    | eof { () }
+    | _ { failwith "not a comment" }
+
+    and comment depth = parse
+    | "(*" { comment (depth + 1) lexbuf }
+    | "*)" { if depth > 0 then comment (depth - 1) lexbuf }
+    | eof { failwith "unterminated comment" }
+    | '\n' { Lexing.new_line lexbuf; comment depth lexbuf }
+    | _ { comment depth lexbuf }
     |}]

--- a/test/menhirformat/ocamllex_tests.ml
+++ b/test/menhirformat/ocamllex_tests.ml
@@ -1,0 +1,43 @@
+open Menhirformat_lib
+open Utils
+module Mll = OcamllexSyntax
+module MF = Ocamllex
+
+let config : Config.t = { tabsize = 2 }
+
+let helper text : unit =
+  text |> Mll.Main.parse_string
+  |> Result.fold
+       ~ok:(fun partial_grammar ->
+         MF.main ~config ~ast:partial_grammar
+           ~doc:
+             (TD.make ~position_encoding:`UTF8
+                {
+                  textDocument =
+                    {
+                      languageId = "";
+                      text;
+                      uri = Uri.of_path "foo/bar";
+                      version = 0;
+                    };
+                }))
+       ~error:(fun (msg, range) -> spr "%s at %s" msg (Mll.Range.show range))
+  |> print_endline
+
+let%expect_test "It handles escape sequences correctly" =
+  helper
+    {|rule next_token = parse
+    | "\t" | "\ " {next_token lexbuf}
+  | "\n" | '\n' | "\r"  {Lexing.new_line ()}
+  | '\\'
+  | "\\"                      { lexer_logger "\\"; Parser.LDIVIDE }
+  | "\\" ("[a-z]" as c) { Printf.printf "got rare backslash sequence: \"\\%c\"\n" c}
+|};
+  [%expect {|
+    rule next_token = parse
+      | "\t" | " " { next_token lexbuf }
+      | "\n" | '\n' | "\r" { Lexing.new_line () }
+      | '\\' | "\\" { lexer_logger "\\"; Parser.LDIVIDE }
+      | "\\" ("[a-z]" as c)
+        { Printf.printf "got rare backslash sequence: \"\\%c\"\n" c }
+    |}]

--- a/vendor/menhir/Action.ml
+++ b/vendor/menhir/Action.ml
@@ -21,6 +21,8 @@ type t = {
   (**The free variables that this semantic action can use in order to
      refer to a semantic value. *)
 
+  keyword_lst  : keyword list; (* [menhir-lsp] We keep also the keywords in a list as it helps the formatter process them in the same order they are scanned. *)
+
   keywords  : KeywordSet.t;
   (**The set of keywords that appear in this semantic action. These keywords
      can be thought of as free variables that refer to positions. They must
@@ -40,8 +42,9 @@ type t = {
 (* Construction. *)
 
 let make priority semvars keywords expr =
+  let keyword_lst = keywords in
   let keywords = KeywordSet.of_list keywords in
-  { expr; semvars; keywords; priority }
+  { expr; semvars; keyword_lst; keywords; priority }
 
 (* -------------------------------------------------------------------------- *)
 
@@ -52,7 +55,7 @@ let compose x a1 a2 =
   and semvars   = StringSet.(union a1.semvars (remove x a2.semvars))
   and keywords  = KeywordSet.union a1.keywords a2.keywords
   and priority  = max a1.priority a2.priority in
-  { expr; semvars; keywords; priority }
+  { expr; semvars; keyword_lst = []; keywords; priority }
 
 (* Building [let p = x in a]. *)
 
@@ -61,7 +64,7 @@ let bind bvp p x a =
   and semvars   = StringSet.(add x (diff a.semvars (of_list bvp)))
   and keywords  = a.keywords
   and priority  = a.priority in
-  { expr; semvars; keywords; priority }
+  { expr; semvars; keyword_lst = []; keywords; priority }
 
 (* -------------------------------------------------------------------------- *)
 
@@ -77,7 +80,7 @@ let[@inline] keywords action =
   action.keywords
 
 let has_beforeend action =
-  KeywordSet.mem (Position ("", Before, WhereEnd, FlavorPosition)) action.keywords
+  KeywordSet.mem (Position ({ p = Range.dummy; v = ""; comment = None }, Before, WhereEnd, FlavorPosition)) action.keywords
 
 let posvars action =
   KeywordSet.fold (fun keyword accu ->
@@ -101,7 +104,7 @@ let define keyword keywords f action =
   and semvars   = action.semvars
   and keywords  = KeywordSet.(union keywords (remove keyword action.keywords))
   and priority  = action.priority in
-  { expr; semvars; keywords; priority }
+  { expr; semvars; keyword_lst = []; keywords; priority }
 
 (* -------------------------------------------------------------------------- *)
 

--- a/vendor/menhir/Action.ml
+++ b/vendor/menhir/Action.ml
@@ -77,7 +77,7 @@ let[@inline] keywords action =
   action.keywords
 
 let has_beforeend action =
-  KeywordSet.mem (Position (Before, WhereEnd, FlavorPosition)) action.keywords
+  KeywordSet.mem (Position ("", Before, WhereEnd, FlavorPosition)) action.keywords
 
 let posvars action =
   KeywordSet.fold (fun keyword accu ->
@@ -170,7 +170,7 @@ let[@inline] restrict_semvar xs { semvar; posvar } =
 
 let rename_keyword f (phi : subst ref) keyword : keyword =
   match keyword with
-  | Position (subject, where, flavor) ->
+  | Position (text, subject, where, flavor) ->
       let subject', where' =
         match f (subject, where) with
         | Some (subject', where') ->
@@ -178,7 +178,7 @@ let rename_keyword f (phi : subst ref) keyword : keyword =
         | None ->
             apply_subject !phi subject, where
       in
-      let keyword' = Position (subject', where', flavor) in
+      let keyword' = Position (text, subject', where', flavor) in
       phi := extend_posvar (kposvar keyword) (kposvar keyword') !phi;
       keyword'
 

--- a/vendor/menhir/Lexer.mll
+++ b/vendor/menhir/Lexer.mll
@@ -230,7 +230,7 @@ let position text range
         ()
   in
   let keyword =
-    Some (Position (text, subject, where, flavor))
+    Some (Position (locate range text, subject, where, flavor))
   and oid =
     None
   in

--- a/vendor/menhir/Lexer.mll
+++ b/vendor/menhir/Lexer.mll
@@ -163,7 +163,8 @@ let dollar range i : monster =
 
 (* The position-keyword monster. The most horrible of all. *)
 
-let position range
+(* [menhir-lsp] The keyword text is given too. *)
+let position text range
   (where : string)
   (flavor : string)
   (i : string option) (x : string option)
@@ -229,7 +230,7 @@ let position range
         ()
   in
   let keyword =
-    Some (Position (subject, where, flavor))
+    Some (Position (text, subject, where, flavor))
   and oid =
     None
   in
@@ -283,6 +284,7 @@ let fragment pos1 pos2 =
 
 (* Create a semantic action. *)
 
+(* [menhir-lsp] All this does basically is replace '$' and parentheses with underscores. (cf. local transforms above) *)
 let transform ofs1 content monsters : string =
   match monsters with
   | [] ->
@@ -297,7 +299,7 @@ let transform ofs1 content monsters : string =
 let priority =
   ref 0
 
-let _make_action pos1 pos2 monsters dollars producers =
+let make_action pos1 pos2 monsters dollars producers =
   (* Check that the monsters are well-formed. *)
   List.iter (fun monster -> monster.check dollars producers) monsters;
   (* Gather all of the identifiers that the semantic action may use to refer
@@ -310,6 +312,11 @@ let _make_action pos1 pos2 monsters dollars producers =
   (* Read the specified chunk of the file. *)
   let content = InputFile.chunk (pos1, pos2) in
   (* Transform the monsters, if there are any. *)
+  (* [menhir-lsp] Problem: menhirformat relies on ocamlformat to format semantic actions.
+  ocamlformat does not speak Menhir keywords. So the monsters must be transformed.
+
+  The output of menhirformat must be Menhir valid code though. So you should hang on to the monsters
+  and reverse their transformation after ocamlformat has done its magic. Bloody. *)
   let ofs1 = pos1.pos_cnum in
   let content = transform ofs1 content monsters in
   (* Construct a fragment. *)
@@ -318,18 +325,6 @@ let _make_action pos1 pos2 monsters dollars producers =
   (* let fragment = Located.parenthesize fragment in *) (* [menhir-lsp] Don't. *)
   (* Build a semantic action. *)
   Action.make !priority ids keywords (IL.ETextual fragment)
-
-let menhir_lsp_make_action pos1 pos2 monsters =
-  let content = InputFile.chunk (pos1, pos2) in
-  (* Transform the monsters, if there are any. *)
-  let ofs1 = pos1.pos_cnum in
-  let content = transform ofs1 content monsters in
-  (* Construct a fragment. *)
-  let fragment = locate (Range.make (pos1, pos2)) content in
-  (* Add parentheses to delimit the semantic action. *)
-  (* let fragment = Located.parenthesize fragment in *) (* [menhir-lsp] Don't. *)
-  (* Build a semantic action. *)
-  IL.ETextual fragment
 
 (* ------------------------------------------------------------------------ *)
 
@@ -608,7 +603,7 @@ rule main = parse
       let openingrange = Range.current lexbuf in
       let startpos = lexeme_end_p lexbuf in
       let closingpos, monsters = action false openingrange [] lexbuf in
-      ACTION (menhir_lsp_make_action startpos closingpos monsters)
+      ACTION (make_action startpos closingpos monsters)
         (* Partial application: [dollars] and [producers] are supplied by the
            parser once they are available. *)
     }
@@ -705,7 +700,7 @@ and action percent openingrange monsters = parse
       let monster = dollar (Range.current lexbuf) i in
       action percent openingrange (monster :: monsters) lexbuf }
 | poskeyword
-    { let monster = position (Range.current lexbuf) where flavor i x in
+    { let monster = position (Lexing.lexeme lexbuf) (Range.current lexbuf) where flavor i x in
       action percent openingrange (monster :: monsters) lexbuf }
 | previouserror
     { error lexbuf "$previouserror is no longer supported." }
@@ -748,7 +743,7 @@ and parentheses openingrange monsters = parse
       let monster = dollar (Range.current lexbuf) i in
       parentheses openingrange (monster :: monsters) lexbuf }
 | poskeyword
-    { let monster = position (Range.current lexbuf) where flavor i x in
+    { let monster = position (Lexing.lexeme lexbuf) (Range.current lexbuf) where flavor i x in
       parentheses openingrange (monster :: monsters) lexbuf }
 | previouserror
     { error lexbuf "$previouserror is no longer supported." }

--- a/vendor/menhir/Parser.mly
+++ b/vendor/menhir/Parser.mly
@@ -90,7 +90,7 @@ let last_bar = ref None
 %token <string Located.located Lazy.t>
   PERCENTPERCENT   "%%"
 
-%token <Syntax.action> (* [menhir-lsp] This was [raw_action] *)
+%token <Syntax.raw_action>
   ACTION           "{}"
 
 %token <Attribute.attribute>
@@ -366,11 +366,12 @@ production_group:
         in
         (* Distribute the semantic action and attributes onto every production.
            Also, check that every [$i] is within bounds. *)
-        (* let names = ParserAux.producer_names producers in
-        let pb_action = locate action.p @@ action.v !ParserAux.dollars names in *)
-        (* [menhir-lsp] we'dont distribute the actions across the productions anymore to highlight syntactic structure. *)
+        let producers, _, _ = List.hd productions |> Located.value in
+        let names = ParserAux.producer_names producers in
+        let pb_action = locate action.p @@ action.v !ParserAux.dollars names in
+        (* [menhir-lsp] we'dont distribute the actions across the productions anymore to highlight the syntactic structure. *)
       let pb_productions = productions in
-      let pb_action = action in
+      (* let pb_action = action in *)
       (* [menhir-lsp] The group starts at start position of its first production,
         which is always a leading bar except for the first group's first production. *)
       let startpos = match productions with
@@ -676,7 +677,7 @@ action_expression:
 
 action:
   action = ACTION
-    { XATraditional action }
+    { XATraditional (action `DollarsDisallowed [||]) }
 | action = ANGLED
     { match ParserAux.validate_pointfree_action action with
       | os ->

--- a/vendor/menhir/Syntax.ml
+++ b/vendor/menhir/Syntax.ml
@@ -80,7 +80,7 @@ and identifier = string
 and filename = string
 (**A file name. *)
 
-and action = (IL.expr[@opaque])
+and action = (Action.t[@opaque])
 (**A semantic action. *)
 (* [menhir-lsp] was (Action.t[@opaque]) *)
 

--- a/vendor/menhir/keyword.ml
+++ b/vendor/menhir/keyword.ml
@@ -45,7 +45,7 @@ type subject =
    values or to position information. *)
 
 type keyword =
-  | Position of subject * where * flavor
+  | Position of string * subject * where * flavor
 
 (* ------------------------------------------------------------------------- *)
 (* These auxiliary functions help map a [Position] keyword to the
@@ -88,7 +88,7 @@ let posvar s w f =
 
 let kposvar keyword =
   match keyword with
-  | Position (s, w, f) ->
+  | Position (_, s, w, f) ->
       posvar s w f
 
 (* ------------------------------------------------------------------------- *)

--- a/vendor/menhir/keyword.ml
+++ b/vendor/menhir/keyword.ml
@@ -45,7 +45,7 @@ type subject =
    values or to position information. *)
 
 type keyword =
-  | Position of string * subject * where * flavor
+  | Position of string Located.located * subject * where * flavor
 
 (* ------------------------------------------------------------------------- *)
 (* These auxiliary functions help map a [Position] keyword to the

--- a/vendor/menhir/keyword.mli
+++ b/vendor/menhir/keyword.mli
@@ -55,8 +55,8 @@ type subject =
 (**Keywords inside semantic actions. They allow access to semantic
    values or to position information. *)
    type keyword =
-   | Position of string * subject * where * flavor
-(* [menhir-lsp] Added string component that stores the original text (e.g. $loc) *)
+   | Position of string Located.located * subject * where * flavor
+(* [menhir-lsp] Added [string located] component that stores the original text (e.g. $loc) *)
 
 (**This maps a [Position] keyword to the name of the variable that the
    keyword is replaced with. *)

--- a/vendor/menhir/keyword.mli
+++ b/vendor/menhir/keyword.mli
@@ -54,8 +54,9 @@ type subject =
 
 (**Keywords inside semantic actions. They allow access to semantic
    values or to position information. *)
-type keyword =
-  | Position of subject * where * flavor
+   type keyword =
+   | Position of string * subject * where * flavor
+(* [menhir-lsp] Added string component that stores the original text (e.g. $loc) *)
 
 (**This maps a [Position] keyword to the name of the variable that the
    keyword is replaced with. *)

--- a/vendor/ocamllex/lexer.mll
+++ b/vendor/ocamllex/lexer.mll
@@ -215,7 +215,8 @@ rule main = parse
     { string_buffer#reset_string_buffer ();
       let startp = Lexing.lexeme_start_p lexbuf in
       let endp = handle_lexical_error string Pattern lexbuf in
-      Tstring (Located.locate (startp, endp) (string_buffer#get_stored_string ())) } (* [menhir-lsp] located. *)
+      let content = string_buffer#get_stored_string () |> String.escaped in
+      Tstring (Located.locate (startp, endp) content) } (* [menhir-lsp] located. *)
 (* note: ''' is a valid character literal (by contrast with the compiler) *)
   | "'" [^ '\\'] "'"
     { Tchar(Char.code(Lexing.lexeme_char lexbuf 1)) }
@@ -392,8 +393,9 @@ and action stk = parse
       | _ -> raise_lexical_error lexbuf "Unmatched } in action" }
   | '"'
     { string_buffer#reset_string_buffer ();
-      handle_lexical_error string Action lexbuf |> ignore;
-      action_buffer#store_string @@ spr "\"%s\"" (string_buffer#get_stored_string ());
+      let _ = handle_lexical_error string Action lexbuf in
+      let content = string_buffer#get_stored_string () |> String.escaped in 
+      action_buffer#store_string @@ spr "\"%s\"" content;
       string_buffer#reset_string_buffer ();
       action stk lexbuf }
   | '{' ('%' '%'? extattrident blank*)? (lowercase* as delim) "|"


### PR DESCRIPTION
- fixed formatting of ocamllex string escapes (closes #14)
- fixed formatting of menhir keywords (closes #13)
- added a handful of options to customize the output of `menhirformat`
- improved line breaking logic
- added VS Code settings to configure document formatting